### PR TITLE
Add "Unverified" Servers

### DIFF
--- a/EchoRelay.App/Forms/Controls/GameServersControl.Designer.cs
+++ b/EchoRelay.App/Forms/Controls/GameServersControl.Designer.cs
@@ -55,6 +55,7 @@
             kickToolStripMenuItem = new ToolStripMenuItem();
             contextMenuGameServers = new ContextMenuStrip(components);
             copySessionLobbyIdToolStripMenuItem = new ToolStripMenuItem();
+            columnHeaderVerified = new ColumnHeader();
             ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
             splitContainer1.Panel1.SuspendLayout();
             splitContainer1.Panel2.SuspendLayout();
@@ -67,7 +68,7 @@
             // 
             // listGameServers
             // 
-            listGameServers.Columns.AddRange(new ColumnHeader[] { columnHeaderServerId, columnHeaderIP, columnHeaderBroadcastPort, columnHeaderGametype, columnHeaderLevel, columnHeaderPlayerCount, columnHeaderLobbyType, columnHeaderLocked, columnHeaderChannel, columnHeaderSessionId });
+            listGameServers.Columns.AddRange(new ColumnHeader[] { columnHeaderServerId, columnHeaderIP, columnHeaderBroadcastPort, columnHeaderGametype, columnHeaderLevel, columnHeaderPlayerCount, columnHeaderLobbyType, columnHeaderLocked, columnHeaderChannel, columnHeaderSessionId, columnHeaderVerified });
             listGameServers.Dock = DockStyle.Fill;
             listGameServers.FullRowSelect = true;
             listGameServers.GridLines = true;
@@ -127,7 +128,7 @@
             // columnHeaderSessionId
             // 
             columnHeaderSessionId.Text = "Session/Lobby Identifier";
-            columnHeaderSessionId.Width = 300;
+            columnHeaderSessionId.Width = 240;
             // 
             // splitContainer1
             // 
@@ -248,6 +249,10 @@
             copySessionLobbyIdToolStripMenuItem.Text = "Copy Session / Lobby Id";
             copySessionLobbyIdToolStripMenuItem.Click += copySessionLobbyIdToolStripMenuItem_Click;
             // 
+            // columnHeaderVerified
+            // 
+            columnHeaderVerified.Text = "Verified";
+            // 
             // GameServersControl
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
@@ -294,5 +299,6 @@
         private ToolStripMenuItem copyUserIdToolStripMenuItem;
         private ToolStripMenuItem copyIPAddressToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator1;
+        private ColumnHeader columnHeaderVerified;
     }
 }

--- a/EchoRelay.App/Forms/Controls/GameServersControl.cs
+++ b/EchoRelay.App/Forms/Controls/GameServersControl.cs
@@ -34,7 +34,7 @@ namespace EchoRelay.App.Forms.Controls
             if (!_items.TryGetValue(gameServer.ServerId, out listItem))
             {
                 listItem = new ListViewItem();
-                for (int i = 0; i < 9; i++)
+                for (int i = 0; i < 10; i++)
                     listItem.SubItems.Add("");
                 listGameServers.Items.Add(listItem);
                 _items[gameServer.ServerId] = listItem;
@@ -65,6 +65,7 @@ namespace EchoRelay.App.Forms.Controls
             listItem.SubItems[7].Text = gameServer.SessionLocked.ToString();
             listItem.SubItems[8].Text = gameServer.SessionChannel?.ToString() ?? "-";
             listItem.SubItems[9].Text = gameServer.SessionId?.ToString() ?? "-";
+            listItem.SubItems[10].Text = gameServer.Verified.ToString();
             listItem.Tag = gameServer;
 
             // Update the selected item

--- a/EchoRelay.App/Forms/Controls/GameServersControl.resx
+++ b/EchoRelay.App/Forms/Controls/GameServersControl.resx
@@ -18,7 +18,7 @@
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>

--- a/EchoRelay.App/Forms/Dialogs/SettingsDialog.Designer.cs
+++ b/EchoRelay.App/Forms/Dialogs/SettingsDialog.Designer.cs
@@ -50,6 +50,7 @@
             btnRegenerateAPIKey = new Button();
             txtServerDBApiKey = new TextBox();
             chkUseServerDBApiKeys = new CheckBox();
+            chkAllowUnverifiedServers = new CheckBox();
             groupBoxGame.SuspendLayout();
             groupBoxServer.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)numericTCPPort).BeginInit();
@@ -213,7 +214,7 @@
             // btnSaveSettings
             // 
             btnSaveSettings.Anchor = AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
-            btnSaveSettings.Location = new Point(12, 378);
+            btnSaveSettings.Location = new Point(12, 391);
             btnSaveSettings.Name = "btnSaveSettings";
             btnSaveSettings.Size = new Size(500, 23);
             btnSaveSettings.TabIndex = 6;
@@ -226,7 +227,7 @@
             groupBoxMatching.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             groupBoxMatching.Controls.Add(chkForceIntoAnySession);
             groupBoxMatching.Controls.Add(chkPopulationOverPing);
-            groupBoxMatching.Location = new Point(12, 293);
+            groupBoxMatching.Location = new Point(12, 305);
             groupBoxMatching.Name = "groupBoxMatching";
             groupBoxMatching.Size = new Size(500, 79);
             groupBoxMatching.TabIndex = 7;
@@ -260,12 +261,13 @@
             // groupBox1
             // 
             groupBox1.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            groupBox1.Controls.Add(chkAllowUnverifiedServers);
             groupBox1.Controls.Add(btnRegenerateAPIKey);
             groupBox1.Controls.Add(txtServerDBApiKey);
             groupBox1.Controls.Add(chkUseServerDBApiKeys);
             groupBox1.Location = new Point(12, 222);
             groupBox1.Name = "groupBox1";
-            groupBox1.Size = new Size(500, 65);
+            groupBox1.Size = new Size(500, 76);
             groupBox1.TabIndex = 8;
             groupBox1.TabStop = false;
             groupBox1.Text = "ServerDB Settings";
@@ -303,11 +305,21 @@
             chkUseServerDBApiKeys.UseVisualStyleBackColor = true;
             chkUseServerDBApiKeys.CheckedChanged += chkUseServerDBApiKeys_CheckedChanged;
             // 
+            // chkAllowUnverifiedServers
+            // 
+            chkAllowUnverifiedServers.AutoSize = true;
+            chkAllowUnverifiedServers.Location = new Point(6, 47);
+            chkAllowUnverifiedServers.Name = "chkAllowUnverifiedServers";
+            chkAllowUnverifiedServers.Size = new Size(153, 19);
+            chkAllowUnverifiedServers.TabIndex = 11;
+            chkAllowUnverifiedServers.Text = "Allow Unverified Servers";
+            chkAllowUnverifiedServers.UseVisualStyleBackColor = true;
+            // 
             // SettingsDialog
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(524, 409);
+            ClientSize = new Size(524, 422);
             Controls.Add(groupBox1);
             Controls.Add(groupBoxMatching);
             Controls.Add(btnSaveSettings);
@@ -352,5 +364,6 @@
         private TextBox txtServerDBApiKey;
         private CheckBox chkUseServerDBApiKeys;
         private Button btnRegenerateAPIKey;
+        private CheckBox chkAllowUnverifiedServers;
     }
 }

--- a/EchoRelay.App/Forms/Dialogs/SettingsDialog.cs
+++ b/EchoRelay.App/Forms/Dialogs/SettingsDialog.cs
@@ -31,6 +31,7 @@ namespace EchoRelay.App.Forms.Dialogs
             if (Settings.FilesystemDatabaseDirectory != null)
                 txtDbFolder.Text = Settings.FilesystemDatabaseDirectory;
             chkStartServerOnStartup.Checked = Settings.StartServerOnStartup;
+            chkAllowUnverifiedServers.Checked = Settings.ServerDBAllowUnverifiedServers;
             chkPopulationOverPing.Checked = Settings.MatchingPopulationOverPing;
             chkForceIntoAnySession.Checked = Settings.MatchingForceIntoAnySessionOnFailure;
 
@@ -104,6 +105,7 @@ namespace EchoRelay.App.Forms.Dialogs
             Settings.MongoDBConnectionString = null; // TODO: currently unsupported
             Settings.StartServerOnStartup = chkStartServerOnStartup.Checked;
             Settings.ServerDBApiKey = newServerDbApiKey;
+            Settings.ServerDBAllowUnverifiedServers = chkAllowUnverifiedServers.Checked;
             Settings.MatchingPopulationOverPing = chkPopulationOverPing.Checked;
             Settings.MatchingForceIntoAnySessionOnFailure = chkForceIntoAnySession.Checked;
 

--- a/EchoRelay.App/Forms/Dialogs/SettingsDialog.resx
+++ b/EchoRelay.App/Forms/Dialogs/SettingsDialog.resx
@@ -18,7 +18,7 @@
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>

--- a/EchoRelay.App/Forms/MainWindow.cs
+++ b/EchoRelay.App/Forms/MainWindow.cs
@@ -103,10 +103,11 @@ namespace EchoRelay
             // Create a server instance and set up our event handlers
             Server = new Server(serverStorage,
                 new ServerSettings(
-                    port: Settings.Port,
-                    serverDbApiKey: Settings.ServerDBApiKey,
-                    favorPopulationOverPing: Settings.MatchingPopulationOverPing,
-                    forceIntoAnySessionIfCreationFails: Settings.MatchingForceIntoAnySessionOnFailure
+                        port: Settings.Port,
+                        serverDbApiKey: Settings.ServerDBApiKey,
+                        serverDbAllowUnverifiedServers: Settings.ServerDBAllowUnverifiedServers,
+                        favorPopulationOverPing: Settings.MatchingPopulationOverPing,
+                        forceIntoAnySessionIfCreationFails: Settings.MatchingForceIntoAnySessionOnFailure
                     )
                 );
             Server.OnServerStarted += Server_OnServerStarted;

--- a/EchoRelay.App/Settings/AppSettings.cs
+++ b/EchoRelay.App/Settings/AppSettings.cs
@@ -60,6 +60,9 @@ namespace EchoRelay.App.Settings
         [JsonProperty("serverdb_api_key")]
         public string? ServerDBApiKey { get; set; }
 
+        [JsonProperty("serverdb_allow_unverified_servers")]
+        public bool ServerDBAllowUnverifiedServers { get; set; }
+
 
         /// <summary>
         /// Indicates whether the matching service should first prioritize populating game servers until full, or ping.
@@ -90,7 +93,7 @@ namespace EchoRelay.App.Settings
         {
 
         }
-        public AppSettings(string gameExecutableFilePath = "", ushort port = 0, string? filesystemDatabaseDirectory = null, string? mongoDbConnectionString = null, bool startServerOnStartup = true, string? serverDbApiKey = null, bool matchingPopulationOverPing = true, bool matchingForceIntoAny = true)
+        public AppSettings(string gameExecutableFilePath = "", ushort port = 0, string? filesystemDatabaseDirectory = null, string? mongoDbConnectionString = null, bool startServerOnStartup = true, string? serverDbApiKey = null, bool serverDbAllowUnverifiedServers = false, bool matchingPopulationOverPing = true, bool matchingForceIntoAny = true)
         {
             GameExecutableFilePath = gameExecutableFilePath;
             Port = port;
@@ -98,6 +101,7 @@ namespace EchoRelay.App.Settings
             MongoDBConnectionString = mongoDbConnectionString;
             StartServerOnStartup = startServerOnStartup;
             ServerDBApiKey = serverDbApiKey;
+            ServerDBAllowUnverifiedServers = serverDbAllowUnverifiedServers;
             MatchingPopulationOverPing = matchingPopulationOverPing;
             MatchingForceIntoAnySessionOnFailure = matchingForceIntoAny;
         }

--- a/EchoRelay.Core/Server/ServerSettings.cs
+++ b/EchoRelay.Core/Server/ServerSettings.cs
@@ -56,6 +56,8 @@ namespace EchoRelay.Core.Server
         /// </summary>
         public string? ServerDBApiKey { get; }
 
+        public bool ServerDBAllowUnverifiedServers { get; }
+
         /// <summary>
         /// Indicates whether the matching service should try to force the user into any available game server,
         /// in the event that there are not enough game servers to create the requested session.
@@ -74,7 +76,7 @@ namespace EchoRelay.Core.Server
         public ServerSettings(ushort port = 777, string apiServicePath = "/api", string configServicePath = "/config",
             string loginServicePath = "/login", string matchingServicePath = "/matching",
             string serverdbServicePath = "/serverdb", string transactionServicePath = "/transaction", TimeSpan? disconnectedSessionTimeout = null,
-            string? serverDbApiKey = null, bool forceIntoAnySessionIfCreationFails = false, bool favorPopulationOverPing = true)
+            string? serverDbApiKey = null, bool serverDbAllowUnverifiedServers = false, bool forceIntoAnySessionIfCreationFails = false, bool favorPopulationOverPing = true)
         {
             Port = port;
             ApiServicePath = apiServicePath;
@@ -86,6 +88,7 @@ namespace EchoRelay.Core.Server
 
             SessionDisconnectedTimeout = disconnectedSessionTimeout ?? TimeSpan.FromMinutes(1);
             ServerDBApiKey = string.IsNullOrEmpty(serverDbApiKey) ? null : serverDbApiKey;
+            ServerDBAllowUnverifiedServers = serverDbAllowUnverifiedServers;
             ForceIntoAnySessionIfCreationFails = forceIntoAnySessionIfCreationFails;
             FavorPopulationOverPing = favorPopulationOverPing;
         }
@@ -117,7 +120,7 @@ namespace EchoRelay.Core.Server
                 apiServiceHost: httpHost + ApiServicePath,
                 configServiceHost: webSocketHost + ConfigServicePath,
                 loginServiceHost: webSocketHost + LoginServicePath + $"?auth=AccountPassword&displayname=AccountName",
-                matchingServiceHost: webSocketHost + MatchingServicePath,
+                matchingServiceHost: webSocketHost + MatchingServicePath + "?unverifiedservers=false",
                 serverdbServiceHost: serverConfig ? serverDBHost : null,
                 transactionServiceHost: webSocketHost + TransactionServicePath,
                 publisherLock: publisherLock

--- a/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
+++ b/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
@@ -271,7 +271,7 @@ namespace EchoRelay.Core.Server.Services.Matching
                     channel: matchingSession.Channel,
                     locked: false,
                     lobbyTypes: matchingSession.SearchLobbyTypes,
-                    unfilledServerOnly: false,
+                    unfilledServerOnly: true,
                     includeUnverified: includeUnverifiedServers
                 );
 

--- a/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
+++ b/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
@@ -5,6 +5,8 @@ using EchoRelay.Core.Server.Messages.Matching;
 using EchoRelay.Core.Server.Services.ServerDB;
 using EchoRelay.Core.Server.Storage.Types;
 using EchoRelay.Core.Utils;
+using System.Collections.Specialized;
+using System.Web;
 using static EchoRelay.Core.Server.Messages.ServerDB.ERGameServerStartSession;
 
 namespace EchoRelay.Core.Server.Services.Matching
@@ -162,6 +164,9 @@ namespace EchoRelay.Core.Server.Services.Matching
                 return;
             }
 
+            NameValueCollection queryStrings = HttpUtility.ParseQueryString(sender.RequestUri.Query);
+            bool includeUnverifiedServers = queryStrings.Get("unverifiedservers") == "true";
+
             // This is a create lobby, or find lobby request. We will try to find an existing server that matches the request.
             // Filter game servers, produce ping request endpoint data.
             // We limit the amount to 100, to avoid the response hitting the max packet size.
@@ -173,7 +178,8 @@ namespace EchoRelay.Core.Server.Services.Matching
                 channel: matchingSession.Channel,
                 locked: false,
                 lobbyTypes: matchingSession.SearchLobbyTypes,
-                unfilledServerOnly: true
+                unfilledServerOnly: true,
+                includeUnverified: includeUnverifiedServers
             );
 
             // If we only have one game server, immediately connect the peer. Otherwise, perform a ping request to determine the lowest ping server.
@@ -193,7 +199,7 @@ namespace EchoRelay.Core.Server.Services.Matching
                         gameServer.InternalAddress,
                         gameServer.ExternalAddress,
                         gameServer.Port
-                        );
+                    );
                 }
 
                 // Send a ping request to the peer.
@@ -232,6 +238,9 @@ namespace EchoRelay.Core.Server.Services.Matching
             // Try to select a game server
             RegisteredGameServer? selectedGameServer = null;
 
+            NameValueCollection queryStrings = HttpUtility.ParseQueryString(sender.RequestUri.Query);
+            bool includeUnverifiedServers = queryStrings.Get("unverifiedservers") == "true";
+
             // If we have no results, there are likely no game servers available to serve the request.
             // See if the user specified that they wish to force users in this scenario to join any available server.
             if (request.Results.Length == 0)
@@ -239,9 +248,9 @@ namespace EchoRelay.Core.Server.Services.Matching
                 if (Server.Settings.ForceIntoAnySessionIfCreationFails)
                 {
                     // Resolve the most populated available game server with open space and select it.
-                    selectedGameServer = Server.ServerDBService.Registry.FilterGameServers(locked: false, unfilledServerOnly: true, lobbyTypes: new LobbyType[] {LobbyType.Unassigned, LobbyType.Public})
+                    selectedGameServer = Server.ServerDBService.Registry.FilterGameServers(locked: false, unfilledServerOnly: true, lobbyTypes: new LobbyType[] { LobbyType.Unassigned, LobbyType.Public }, includeUnverified: includeUnverifiedServers)
                         .MaxBy(x => (float)x.SessionPlayerCount / x.SessionPlayerLimit);
-                } 
+                }
                 else
                 {
                     await SendLobbySessionFailure(sender, LobbySessionFailureErrorCode.ServerFindFailed, "Could not receive a ping response from any game servers");
@@ -262,9 +271,10 @@ namespace EchoRelay.Core.Server.Services.Matching
                     channel: matchingSession.Channel,
                     locked: false,
                     lobbyTypes: matchingSession.SearchLobbyTypes,
-                    unfilledServerOnly: true
+                    unfilledServerOnly: false,
+                    includeUnverified: includeUnverifiedServers
                 );
-                
+
                 // All servers should either have no session started, or match the criteria we filtered for.
                 // Depending on our matching strategy, we will first sort by population or ping, followed by the latter.
                 // The most optimal game server will be selected.
@@ -272,11 +282,12 @@ namespace EchoRelay.Core.Server.Services.Matching
                 {
                     // Select the game server which is most full.
                     selectedGameServer = gameServers.MaxBy(x => (float)x.SessionPlayerCount / x.SessionPlayerLimit);
-                } 
+                }
                 else
                 {
                     // Sort the game servers with preference of filters: session started, lowest ping, highest player count.
-                    var sortedGameServers = gameServers.Select(gameServer => {
+                    var sortedGameServers = gameServers.Select(gameServer =>
+                    {
                         uint? pingMilliseconds = pingResultLookup.TryGetValue((gameServer.InternalAddress.ToUInt32(), gameServer.ExternalAddress.ToUInt32()), out uint p) ? p : uint.MaxValue;
                         return (gameServer, pingMilliseconds);
                     }).OrderBy(x => x.gameServer.SessionStarted ? 0 : 1).ThenBy(x => x.pingMilliseconds).ThenBy(x => (float)x.gameServer.SessionPlayerCount / x.gameServer.SessionPlayerLimit);

--- a/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
@@ -38,10 +38,10 @@ namespace EchoRelay.Core.Server.Services.ServerDB
         #endregion
 
         #region Functions
-        public RegisteredGameServer RegisterGameServer(Peer peer, ERGameServerRegistrationRequest request)
+        public RegisteredGameServer RegisterGameServer(Peer peer, ERGameServerRegistrationRequest request, bool verified)
         {
             // Create a new registered server and set it in our lookup.
-            RegisteredGameServer registeredGameServer = new RegisteredGameServer(this, peer, request);
+            RegisteredGameServer registeredGameServer = new RegisteredGameServer(this, peer, request, verified);
             RegisteredGameServers[registeredGameServer.ServerId] = registeredGameServer;
 
             // Fire the relevant event for the game server being registered.
@@ -77,7 +77,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
 
         public IEnumerable<RegisteredGameServer> FilterGameServers(int? findMax = null, ulong? serverId = null, Guid? sessionId = null,
             HashSet<(uint InternalAddr, uint ExternalAddr)>? addresses = null, ushort? port = null,
-            long? gameTypeSymbol = null, long? levelSymbol = null, Guid? channel = null, bool? locked = null, LobbyType[]? lobbyTypes = null, bool unfilledServerOnly = true)
+            long? gameTypeSymbol = null, long? levelSymbol = null, Guid? channel = null, bool? locked = null, LobbyType[]? lobbyTypes = null, bool unfilledServerOnly = true, bool includeUnverified = false)
         {
             // Filter through all game servers
             List<RegisteredGameServer> filteredGameServers = new List<RegisteredGameServer>();
@@ -93,6 +93,8 @@ namespace EchoRelay.Core.Server.Services.ServerDB
                 else if (addresses != null && !addresses.Contains((gameServer.InternalAddress.ToUInt32(), gameServer.ExternalAddress.ToUInt32())))
                     continue;
                 else if (port != null && gameServer.Peer.Port != port)
+                    continue;
+                else if (!includeUnverified && !gameServer.Verified)
                     continue;
 
                 // If the session is started, filter on that criteria.

--- a/EchoRelay.Core/Server/Services/ServerDB/RegisteredGameServer.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/RegisteredGameServer.cs
@@ -145,6 +145,8 @@ namespace EchoRelay.Core.Server.Services.ServerDB
         /// A lock used for asynchronous/awaitable concurrent access to this object.
         /// </summary>
         public AsyncLock _accessLock;
+
+        public bool Verified { get; private set; }
         #endregion
 
         #region Events
@@ -184,7 +186,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
         #endregion
 
         #region Constructor
-        public RegisteredGameServer(GameServerRegistry registry, Peer peer, ERGameServerRegistrationRequest registrationRequest)
+        public RegisteredGameServer(GameServerRegistry registry, Peer peer, ERGameServerRegistrationRequest registrationRequest, bool verified)
         {
             Registry = registry;
             Peer = peer;
@@ -193,6 +195,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             SessionPlayerLimit = 16;
             _playerSessions = new Dictionary<Guid, Peer>();
             _accessLock = new AsyncLock();
+            Verified = verified;
         }
         #endregion
 

--- a/EchoRelay.Core/Server/Services/ServerDB/ServerDBService.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/ServerDBService.cs
@@ -90,13 +90,22 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             // Validate the API key if we enforce one.
             if (Server.Settings.ServerDBApiKey != null && apiKey != Server.Settings.ServerDBApiKey)
             {
-                await sender.Send(new LobbyRegistrationFailure(LobbyRegistrationFailure.FailureCode.DatabaseError));
-                return;
-            }
+                if (apiKey != null || !Server.Settings.ServerDBAllowUnverifiedServers)
+                {
+                    await sender.Send(new LobbyRegistrationFailure(LobbyRegistrationFailure.FailureCode.DatabaseError));
+                    return;
+                }
 
-            // Register the game server and update our session data with it.
-            RegisteredGameServer registeredGameServer = Registry.RegisterGameServer(sender, request);
-            sender.SetSessionData(registeredGameServer);
+                // Register the game server and update our session data with it.
+                RegisteredGameServer registeredGameServer = Registry.RegisterGameServer(sender, request, false);
+                sender.SetSessionData(registeredGameServer);
+            }
+            else
+            {
+                // Register the game server and update our session data with it.
+                RegisteredGameServer registeredGameServer = Registry.RegisterGameServer(sender, request, true);
+                sender.SetSessionData(registeredGameServer);
+            }
 
             // Send our registration success message.
             await sender.Send(new LobbyRegistrationSuccess(request.ServerId, sender.Address));


### PR DESCRIPTION
If enabled, this allows anyone to connect a server to your relay instance with an "unverified" flag. Users will only be able to utilize these unverified servers by enabling the "unverifiedservers" matching parameter in their config. Ideally, this should be used to help determine who to trust with hosting verified servers by receiving feedback about uptime and lag from users who are willing to risk the potential instability for more server capacity.

As always, I'm not a good C# dev, so please feel free to let me know what I should change to keep it more in-line with the project.
Oh yeah, I also didn't add comments... If it's a necessary thing, I would appreciate it if someone could help, as I suck at commenting my code :/