### PR TITLE
Add public HTTP API endpoints for centralized app

### DIFF
--- a/EchoRelay.App/Forms/Controls/ServerInfoControl.cs
+++ b/EchoRelay.App/Forms/Controls/ServerInfoControl.cs
@@ -40,13 +40,13 @@ namespace EchoRelay.App.Forms.Controls
             }
             
             
-            _apiManager.peerStatsObject.serverIP = server?.PublicIPAddress?.ToString() ?? "localhost";
-            _apiManager.peerStatsObject.login = server?.LoginService.Peers.Count ?? 0;
-            _apiManager.peerStatsObject.matching = server?.MatchingService.Peers.Count ?? 0;
-            _apiManager.peerStatsObject.config = server?.ConfigService.Peers.Count ?? 0;
-            _apiManager.peerStatsObject.transaction = server?.TransactionService.Peers.Count ?? 0;
-            _apiManager.peerStatsObject.serverdb = server?.ServerDBService.Peers.Count ?? 0;
-            _apiManager.PeerStats.EditPeerStats(_apiManager.peerStatsObject, server?.PublicIPAddress.ToString());
+            _apiManager.peerStatsObject.ServerIp = server?.PublicIPAddress?.ToString() ?? "localhost";
+            _apiManager.peerStatsObject.Login = server?.LoginService.Peers.Count ?? 0;
+            _apiManager.peerStatsObject.Matching = server?.MatchingService.Peers.Count ?? 0;
+            _apiManager.peerStatsObject.Config = server?.ConfigService.Peers.Count ?? 0;
+            _apiManager.peerStatsObject.Transaction = server?.TransactionService.Peers.Count ?? 0;
+            _apiManager.peerStatsObject.ServerDb = server?.ServerDBService.Peers.Count ?? 0;
+            Task.Run(() => _apiManager.PeerStats.EditPeerStats(_apiManager.peerStatsObject, server?.PublicIPAddress?.ToString() ?? "localhost"));
 
         }
 

--- a/EchoRelay.App/Forms/Controls/ServerInfoControl.cs
+++ b/EchoRelay.App/Forms/Controls/ServerInfoControl.cs
@@ -1,11 +1,13 @@
-﻿using EchoRelay.Core.Server;
+﻿using EchoRelay.Core.Monitoring;
 using EchoRelay.Core.Utils;
 using Newtonsoft.Json;
+using Server = EchoRelay.Core.Server.Server;
 
 namespace EchoRelay.App.Forms.Controls
 {
     public partial class ServerInfoControl : UserControl
     {
+        ApiManager apiManager = new ApiManager();
         public ServerInfoControl()
         {
             InitializeComponent();
@@ -36,6 +38,20 @@ namespace EchoRelay.App.Forms.Controls
                     rtbGeneratedServiceConfig.Text = "";
                 }
             }
+            //Edit server monitoring
+            /*
+            ServiceConfig serviceConfig = server.Settings.GenerateServiceConfig(hostName);
+            ServerObject serverObject = new ServerObject();
+            serverObject.ip = hostName;
+            serverObject.apiservice_host = serviceConfig.ApiServiceHost;
+            serverObject.configservice_host = serviceConfig.ConfigServiceHost;
+            serverObject.loginservice_host = serviceConfig.LoginServiceHost;
+            serverObject.matchingservice_host = serviceConfig.MatchingServiceHost;
+            serverObject.serverdb_host = serviceConfig.ServerDBServiceHost;
+            serverObject.transactionservice_host = serviceConfig.TransactionServiceHost;
+            serverObject.publisher_lock = serviceConfig.PublisherLock;
+            await apiManager.Server.EditServer(serverObject, hostName);
+            */
         }
 
         private void btnCopyServiceConfig_Click(object sender, EventArgs e)

--- a/EchoRelay.App/Forms/Controls/ServerInfoControl.cs
+++ b/EchoRelay.App/Forms/Controls/ServerInfoControl.cs
@@ -38,20 +38,16 @@ namespace EchoRelay.App.Forms.Controls
                     rtbGeneratedServiceConfig.Text = "";
                 }
             }
-            //Edit server monitoring
-            /*
-            ServiceConfig serviceConfig = server.Settings.GenerateServiceConfig(hostName);
-            ServerObject serverObject = new ServerObject();
-            serverObject.ip = hostName;
-            serverObject.apiservice_host = serviceConfig.ApiServiceHost;
-            serverObject.configservice_host = serviceConfig.ConfigServiceHost;
-            serverObject.loginservice_host = serviceConfig.LoginServiceHost;
-            serverObject.matchingservice_host = serviceConfig.MatchingServiceHost;
-            serverObject.serverdb_host = serviceConfig.ServerDBServiceHost;
-            serverObject.transactionservice_host = serviceConfig.TransactionServiceHost;
-            serverObject.publisher_lock = serviceConfig.PublisherLock;
-            await apiManager.Server.EditServer(serverObject, hostName);
-            */
+            
+            
+            apiManager.peerStatsObject.serverIP = server?.PublicIPAddress?.ToString() ?? "localhost";
+            apiManager.peerStatsObject.login = server?.LoginService.Peers.Count ?? 0;
+            apiManager.peerStatsObject.matching = server?.MatchingService.Peers.Count ?? 0;
+            apiManager.peerStatsObject.config = server?.ConfigService.Peers.Count ?? 0;
+            apiManager.peerStatsObject.transaction = server?.TransactionService.Peers.Count ?? 0;
+            apiManager.peerStatsObject.serverdb = server?.ServerDBService.Peers.Count ?? 0;
+            apiManager.PeerStats.EditPeerStats(apiManager.peerStatsObject, server?.PublicIPAddress.ToString());
+
         }
 
         private void btnCopyServiceConfig_Click(object sender, EventArgs e)

--- a/EchoRelay.App/Forms/Controls/ServerInfoControl.cs
+++ b/EchoRelay.App/Forms/Controls/ServerInfoControl.cs
@@ -7,7 +7,7 @@ namespace EchoRelay.App.Forms.Controls
 {
     public partial class ServerInfoControl : UserControl
     {
-        ApiManager apiManager = new ApiManager();
+        ApiManager _apiManager = ApiManager.Instance;
         public ServerInfoControl()
         {
             InitializeComponent();
@@ -40,13 +40,13 @@ namespace EchoRelay.App.Forms.Controls
             }
             
             
-            apiManager.peerStatsObject.serverIP = server?.PublicIPAddress?.ToString() ?? "localhost";
-            apiManager.peerStatsObject.login = server?.LoginService.Peers.Count ?? 0;
-            apiManager.peerStatsObject.matching = server?.MatchingService.Peers.Count ?? 0;
-            apiManager.peerStatsObject.config = server?.ConfigService.Peers.Count ?? 0;
-            apiManager.peerStatsObject.transaction = server?.TransactionService.Peers.Count ?? 0;
-            apiManager.peerStatsObject.serverdb = server?.ServerDBService.Peers.Count ?? 0;
-            apiManager.PeerStats.EditPeerStats(apiManager.peerStatsObject, server?.PublicIPAddress.ToString());
+            _apiManager.peerStatsObject.serverIP = server?.PublicIPAddress?.ToString() ?? "localhost";
+            _apiManager.peerStatsObject.login = server?.LoginService.Peers.Count ?? 0;
+            _apiManager.peerStatsObject.matching = server?.MatchingService.Peers.Count ?? 0;
+            _apiManager.peerStatsObject.config = server?.ConfigService.Peers.Count ?? 0;
+            _apiManager.peerStatsObject.transaction = server?.TransactionService.Peers.Count ?? 0;
+            _apiManager.peerStatsObject.serverdb = server?.ServerDBService.Peers.Count ?? 0;
+            _apiManager.PeerStats.EditPeerStats(_apiManager.peerStatsObject, server?.PublicIPAddress.ToString());
 
         }
 

--- a/EchoRelay.App/Forms/MainWindow.cs
+++ b/EchoRelay.App/Forms/MainWindow.cs
@@ -135,7 +135,7 @@ namespace EchoRelay
             Server.ServerDBService.Registry.OnGameServerUnregistered += Registry_OnGameServerUnregistered;
             Server.ServerDBService.OnGameServerRegistrationFailure += ServerDBService_OnGameServerRegistrationFailure; ;
 
-            apiManager = new ApiManager();
+            apiManager = ApiManager.Instance;
         }
         #endregion
 

--- a/EchoRelay.App/Forms/MainWindow.cs
+++ b/EchoRelay.App/Forms/MainWindow.cs
@@ -13,6 +13,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using EchoRelay.Core.Monitoring;
+using Server = EchoRelay.Core.Server.Server;
 
 namespace EchoRelay
 {
@@ -36,6 +38,8 @@ namespace EchoRelay
         /// The websocket server used to power central game services.
         /// </summary>
         public Server Server { get; set; }
+        
+        public ApiManager apiManager { get; set; }
 
         /// <summary>
         /// The UI editors for different storage resources.
@@ -130,6 +134,8 @@ namespace EchoRelay
             Server.ServerDBService.Registry.OnGameServerRegistered += Registry_OnGameServerRegistered;
             Server.ServerDBService.Registry.OnGameServerUnregistered += Registry_OnGameServerUnregistered;
             Server.ServerDBService.OnGameServerRegistrationFailure += ServerDBService_OnGameServerRegistrationFailure; ;
+
+            apiManager = new ApiManager();
         }
         #endregion
 
@@ -359,6 +365,9 @@ namespace EchoRelay
 
                 // Update server count on the game server tab.
                 tabGameServers.Text = $"Game Servers ({gameServersControl.GameServerCount})";
+
+                apiManager.peerStatsObject.gameServers = gameServersControl.GameServerCount;
+                apiManager.PeerStats.EditPeerStats(apiManager.peerStatsObject, Server.PublicIPAddress.ToString());
 
                 AppendLogText($"[{gameServer.Peer.Service.Name}] client({gameServer.Peer.Address}:{gameServer.Peer.Port}) registered game server (server_id={gameServer.ServerId}, region_symbol={gameServer.RegionSymbol}, version_lock={gameServer.VersionLock}, endpoint=<{gameServer.ExternalAddress}:{gameServer.Port}>)\n");
             });

--- a/EchoRelay.App/Forms/MainWindow.cs
+++ b/EchoRelay.App/Forms/MainWindow.cs
@@ -366,8 +366,8 @@ namespace EchoRelay
                 // Update server count on the game server tab.
                 tabGameServers.Text = $"Game Servers ({gameServersControl.GameServerCount})";
 
-                apiManager.peerStatsObject.gameServers = gameServersControl.GameServerCount;
-                apiManager.PeerStats.EditPeerStats(apiManager.peerStatsObject, Server.PublicIPAddress.ToString());
+                apiManager.peerStatsObject.GameServers = gameServersControl.GameServerCount;
+                Task.Run(() => apiManager.PeerStats.EditPeerStats(apiManager.peerStatsObject, Server.PublicIPAddress?.ToString() ?? "localhost"));
 
                 AppendLogText($"[{gameServer.Peer.Service.Name}] client({gameServer.Peer.Address}:{gameServer.Peer.Port}) registered game server (server_id={gameServer.ServerId}, region_symbol={gameServer.RegionSymbol}, version_lock={gameServer.VersionLock}, endpoint=<{gameServer.ExternalAddress}:{gameServer.Port}>)\n");
             });

--- a/EchoRelay.Cli/Program.cs
+++ b/EchoRelay.Cli/Program.cs
@@ -162,16 +162,6 @@ namespace EchoRelay.Cli
                 Server.ServerDBService.Registry.OnGameServerRegistered += Registry_OnGameServerRegistered;
                 Server.ServerDBService.Registry.OnGameServerUnregistered += Registry_OnGameServerUnregistered;
                 Server.ServerDBService.OnGameServerRegistrationFailure += ServerDBService_OnGameServerRegistrationFailure;
-
-                Server.OnServerStarted += Server_OnServerStarted;
-                Server.OnServerStopped += Server_OnServerStopped;
-                Server.OnAuthorizationResult += Server_OnAuthorizationResult;
-                Server.OnServicePeerConnected += Server_OnServicePeerConnected;
-                Server.OnServicePeerDisconnected += Server_OnServicePeerDisconnected;
-                Server.OnServicePeerAuthenticated += Server_OnServicePeerAuthenticated;
-                Server.ServerDBService.Registry.OnGameServerRegistered += Registry_OnGameServerRegistered;
-                Server.ServerDBService.Registry.OnGameServerUnregistered += Registry_OnGameServerUnregistered;
-                Server.ServerDBService.OnGameServerRegistrationFailure += ServerDBService_OnGameServerRegistrationFailure;
                 
                 // Set up the event handler for the console close event
                 consoleCloseHandler += new EventHandler(ConsoleCloseHandler);
@@ -342,7 +332,7 @@ namespace EchoRelay.Cli
         private static bool ConsoleCloseHandler(CtrlType sig)
         {
             Console.WriteLine("Console is closing. Performing cleanup...");
-            Server.Stop(); // Assuming Server.Stop() is your cleanup function
+            Server.Stop();
     
             Thread.Sleep(1500);
             

--- a/EchoRelay.Cli/Program.cs
+++ b/EchoRelay.Cli/Program.cs
@@ -171,7 +171,7 @@ namespace EchoRelay.Cli
                 consoleCloseHandler += new EventHandler(ConsoleCloseHandler);
                 SetConsoleCtrlHandler(consoleCloseHandler, true);
                 
-                apiManager = new ApiManager();
+                apiManager = ApiManager.Instance;
                 
                 // Set up all verbose event handlers.
                 if (options.Verbose)

--- a/EchoRelay.Cli/Program.cs
+++ b/EchoRelay.Cli/Program.cs
@@ -23,13 +23,13 @@ namespace EchoRelay.Cli
         /// <summary>
         /// The instance of the server hosting central services.
         /// </summary>
-        private static Server Server;
+        private static Server? Server;
         /// <summary>
         /// The update timer used to trigger a peer stats update on a given interval.
         /// </summary>
         private static System.Timers.Timer? peerStatsUpdateTimer;
 
-        private static ApiManager apiManager;
+        private static ApiManager? apiManager;
         /// <summary>
         /// The time that the server was started.
         /// </summary>
@@ -43,7 +43,7 @@ namespace EchoRelay.Cli
         private static extern bool SetConsoleCtrlHandler(EventHandler handler, bool add);
 
         private delegate bool EventHandler(CtrlType sig);
-        private static EventHandler consoleCloseHandler;
+        private static EventHandler? consoleCloseHandler;
 
         // Enum to represent different CtrlTypes
         private enum CtrlType
@@ -247,15 +247,15 @@ namespace EchoRelay.Cli
 
         private static void updateServerInfo()
         {
-            apiManager.peerStatsObject.serverIP = Server.PublicIPAddress?.ToString() ?? "localhost";
-            apiManager.peerStatsObject.login = Server.LoginService.Peers.Count;
-            apiManager.peerStatsObject.matching = Server.MatchingService.Peers.Count;
-            apiManager.peerStatsObject.config = Server.ConfigService.Peers.Count;
-            apiManager.peerStatsObject.transaction = Server.TransactionService.Peers.Count;
-            apiManager.peerStatsObject.serverdb = Server.ServerDBService.Peers.Count;
-            apiManager.peerStatsObject.gameServers = Server.ServerDBService.Registry.RegisteredGameServers.Count;
+            apiManager.peerStatsObject.ServerIp = Server?.PublicIPAddress?.ToString() ?? "localhost";
+            apiManager.peerStatsObject.Login = Server?.LoginService.Peers.Count;
+            apiManager.peerStatsObject.Matching = Server?.MatchingService.Peers.Count;
+            apiManager.peerStatsObject.Config = Server?.ConfigService.Peers.Count;
+            apiManager.peerStatsObject.Transaction = Server?.TransactionService.Peers.Count;
+            apiManager.peerStatsObject.ServerDb = Server?.ServerDBService.Peers.Count;
+            apiManager.peerStatsObject.GameServers = Server?.ServerDBService.Registry.RegisteredGameServers.Count;
             
-            apiManager.PeerStats.EditPeerStats(apiManager.peerStatsObject, apiManager.peerStatsObject.serverIP);
+            Task.Run(() => apiManager.PeerStats.EditPeerStats(apiManager.peerStatsObject, apiManager.peerStatsObject.ServerIp));
         }
         private static void Server_OnServicePeerConnected(Core.Server.Services.Service service, Core.Server.Services.Peer peer)
         {
@@ -353,7 +353,7 @@ namespace EchoRelay.Cli
         private static bool ConsoleCloseHandler(CtrlType sig)
         {
             Console.WriteLine("Console is closing. Performing cleanup...");
-            Server.Stop();
+            Server?.Stop();
     
             Thread.Sleep(1500);
             

--- a/EchoRelay.Core/Monitoring/ApiClient.cs
+++ b/EchoRelay.Core/Monitoring/ApiClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Security.Cryptography;
+using System.Text;
 
 namespace EchoRelay.Core.Monitoring;
     
@@ -15,7 +16,8 @@ public class ApiClient
         };
     }
 
-    public async Task<string> EncryptAndSendAsync(string endpoint, string data)
+    //TODO encrypt data to avoid people to send fake data
+    public async Task<string> PostMonitoringData(string endpoint, string data)
     {
         HttpContent content = new StringContent(data, Encoding.UTF8, "application/json");
         HttpResponseMessage response = await _httpClient.PostAsync(endpoint, content);
@@ -27,7 +29,7 @@ public class ApiClient
             throw new Exception($"API request failed with status code: {response.StatusCode}");
     }
 
-    public async Task DeleteAsync(string endpoint)
+    public async Task DeleteMonitoringData(string endpoint)
     {
         HttpResponseMessage response = await _httpClient.DeleteAsync(endpoint);
 
@@ -36,15 +38,5 @@ public class ApiClient
             throw new Exception($"DELETE request failed with status code: {response.StatusCode}");
         }
     }
-    
-    public async Task<string> ReceiveAndDecryptAsync(string endpoint)
-    {
-        HttpResponseMessage response = await _httpClient.GetAsync(endpoint);
 
-        if (response.IsSuccessStatusCode)
-        {
-            return await response.Content.ReadAsStringAsync();
-        }
-        throw new Exception($"API request failed with status code: {response.StatusCode}");
-    }
 }

--- a/EchoRelay.Core/Monitoring/ApiClient.cs
+++ b/EchoRelay.Core/Monitoring/ApiClient.cs
@@ -1,0 +1,50 @@
+﻿using System.Text;
+
+namespace EchoRelay.Core.Monitoring;
+    
+//TO DO : Encrypt data
+public class ApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public ApiClient(string baseUrl)
+    {
+        _httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(baseUrl)
+        };
+    }
+
+    public async Task<string> EncryptAndSendAsync(string endpoint, string data)
+    {
+        HttpContent content = new StringContent(data, Encoding.UTF8, "application/json");
+        HttpResponseMessage response = await _httpClient.PostAsync(endpoint, content);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return await response.Content.ReadAsStringAsync();
+            }
+            throw new Exception($"API request failed with status code: {response.StatusCode}");
+    }
+
+    public async Task DeleteAsync(string endpoint)
+    {
+        HttpResponseMessage response = await _httpClient.DeleteAsync(endpoint);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"DELETE request failed with status code: {response.StatusCode}");
+        }
+    }
+    
+    public async Task<string> ReceiveAndDecryptAsync(string endpoint)
+    {
+        HttpResponseMessage response = await _httpClient.GetAsync(endpoint);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await response.Content.ReadAsStringAsync();
+        }
+        throw new Exception($"API request failed with status code: {response.StatusCode}");
+    }
+}

--- a/EchoRelay.Core/Monitoring/ApiManager.cs
+++ b/EchoRelay.Core/Monitoring/ApiManager.cs
@@ -8,7 +8,7 @@ public class ApiManager
     /// <summary>
     /// Uri to the monitoring API
     /// </summary>
-    public string URI { get; } = "http://localhost:3000/api/";
+    public string URI { get; } = "http://51.75.140.182:3000/api/";
 
     public PeerStatsObject peerStatsObject;
     /// <summary>

--- a/EchoRelay.Core/Monitoring/ApiManager.cs
+++ b/EchoRelay.Core/Monitoring/ApiManager.cs
@@ -8,7 +8,8 @@ public class ApiManager
     /// <summary>
     /// Uri to the monitoring API
     /// </summary>
-    public string URI { get; } = "http://51.75.140.182:3000/api/";
+    public string URI { get; } = "http://localhost:3000/api/";
+    //public string URI { get; } = "http://51.75.140.182:3000/api/";
 
     public PeerStatsObject peerStatsObject;
     /// <summary>
@@ -21,9 +22,9 @@ public class ApiManager
     public GameServer GameServer { get; }
     public PeerStats PeerStats { get; }
 
-    private static ApiManager instance;
+    private static ApiManager instance = new ApiManager();
     
-    public ApiManager()
+    private ApiManager()
     {
         Monitoring = new ApiClient(URI);
         GameServer = new GameServer(Monitoring);
@@ -32,25 +33,9 @@ public class ApiManager
         peerStatsObject = new PeerStatsObject();
     }
     
+    // Method to get the singleton instance
     public static ApiManager Instance
     {
-        get
-        {
-            if (instance == null)
-            {
-                instance = new ApiManager();
-            }
-            return instance;
-        }
-    }
-
-    public static Server ServerEndpoints
-    {
-        get => Instance.Server;
-    }
-    
-    public static GameServer GameServerEndpoints
-    {
-        get => Instance.GameServer;
+        get { return instance; }
     }
 }

--- a/EchoRelay.Core/Monitoring/ApiManager.cs
+++ b/EchoRelay.Core/Monitoring/ApiManager.cs
@@ -8,9 +8,9 @@ public class ApiManager
     /// <summary>
     /// Uri to the monitoring API
     /// </summary>
-    public string URI { get; } = "http://51.75.140.182:3000/api/";
+    public string URI { get; } = "http://localhost:3000/api/";
 
-
+    public PeerStatsObject peerStatsObject;
     /// <summary>
     /// Public key to encrypt data
     /// </summary>
@@ -19,14 +19,17 @@ public class ApiManager
     public Server Server { get; }
     
     public GameServer GameServer { get; }
-    
+    public PeerStats PeerStats { get; }
+
     private static ApiManager instance;
     
     public ApiManager()
     {
         Monitoring = new ApiClient(URI);
         GameServer = new GameServer(Monitoring);
+        PeerStats = new PeerStats(Monitoring);
         Server = new Server(Monitoring);
+        peerStatsObject = new PeerStatsObject();
     }
     
     public static ApiManager Instance

--- a/EchoRelay.Core/Monitoring/ApiManager.cs
+++ b/EchoRelay.Core/Monitoring/ApiManager.cs
@@ -1,0 +1,53 @@
+﻿using System.Security.Cryptography;
+
+namespace EchoRelay.Core.Monitoring;
+
+public class ApiManager
+{
+
+    /// <summary>
+    /// Uri to the monitoring API
+    /// </summary>
+    public string URI { get; } = "http://51.75.140.182:3000/api/";
+
+
+    /// <summary>
+    /// Public key to encrypt data
+    /// </summary>
+    public ApiClient Monitoring { get; }
+    
+    public Server Server { get; }
+    
+    public GameServer GameServer { get; }
+    
+    private static ApiManager instance;
+    
+    public ApiManager()
+    {
+        Monitoring = new ApiClient(URI);
+        GameServer = new GameServer(Monitoring);
+        Server = new Server(Monitoring);
+    }
+    
+    public static ApiManager Instance
+    {
+        get
+        {
+            if (instance == null)
+            {
+                instance = new ApiManager();
+            }
+            return instance;
+        }
+    }
+
+    public static Server ServerEndpoints
+    {
+        get => Instance.Server;
+    }
+    
+    public static GameServer GameServerEndpoints
+    {
+        get => Instance.GameServer;
+    }
+}

--- a/EchoRelay.Core/Monitoring/GameServer.cs
+++ b/EchoRelay.Core/Monitoring/GameServer.cs
@@ -44,11 +44,11 @@ public class GameServer
         }
     }
     
-    public async Task EditGameServer(GameServerObject jsonObject, string sessionId)
+    public async Task EditGameServer(GameServerObject jsonObject, string gameServerID)
     {
         // Create a StringContent with the JSON data and set the content type
         string jsonData = JsonConvert.SerializeObject(jsonObject);
-        string endpoint = $"editGameServer/{sessionId}";
+        string endpoint = $"updateGameServer/{gameServerID}";
 
         try
         {

--- a/EchoRelay.Core/Monitoring/GameServer.cs
+++ b/EchoRelay.Core/Monitoring/GameServer.cs
@@ -18,7 +18,7 @@ public class GameServer
 
         try
         {
-            await _apiClient.DeleteAsync(endpoint);
+            await _apiClient.DeleteMonitoringData(endpoint);
             Console.WriteLine($"Game server with session ID {sessionId} deleted successfully from monitoring.");
         }
         catch (Exception ex)
@@ -35,7 +35,7 @@ public class GameServer
 
         try
         {
-            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            await _apiClient.PostMonitoringData(endpoint, jsonData);
             Console.WriteLine($"Game server successfully added to monitoring.");
         }
         catch (Exception ex)
@@ -52,30 +52,12 @@ public class GameServer
 
         try
         {
-            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            await _apiClient.PostMonitoringData(endpoint, jsonData);
             Console.WriteLine($"Game server successfully edited in monitoring.");
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Error editing the game server in monitoring: {ex.Message}");
-        }
-    }
-    
-    public async Task<string> GetGameServerAsync(string server)
-    {
-        // Define the endpoint for retrieving a game server with the sessionID
-        string endpoint = $"listGameServers/{server}";
-
-        try
-        {
-            string decryptedData = await _apiClient.ReceiveAndDecryptAsync(endpoint);
-            Console.WriteLine($"Game server for {server} retrieved successfully from monitoring.");
-            return decryptedData;
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error retrieving the game server from monitoring: {ex.Message}");
-            return null;
         }
     }
 }

--- a/EchoRelay.Core/Monitoring/GameServer.cs
+++ b/EchoRelay.Core/Monitoring/GameServer.cs
@@ -1,0 +1,81 @@
+﻿using Newtonsoft.Json;
+
+namespace EchoRelay.Core.Monitoring;
+
+public class GameServer
+{
+    private readonly ApiClient _apiClient;
+
+    public GameServer(ApiClient apiClient)
+    {
+        _apiClient = apiClient;
+    }
+
+    public async Task DeleteGameServerAsync(string sessionId)
+    {
+        // Define the endpoint for deleting a game server with the sessionID
+        string endpoint = $"deleteGameServer/{sessionId}";
+
+        try
+        {
+            await _apiClient.DeleteAsync(endpoint);
+            Console.WriteLine($"Game server with session ID {sessionId} deleted successfully from monitoring.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error deleting the game server from monitoring: {ex.Message}");
+        }
+    }
+
+    public async Task AddGameServerAsync(GameServerObject jsonObject)
+    {
+        // Create a StringContent with the JSON data and set the content type
+        string jsonData = JsonConvert.SerializeObject(jsonObject);
+        string endpoint = "addGameServer/";
+
+        try
+        {
+            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            Console.WriteLine($"Game server successfully added to monitoring.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error adding the game server from monitoring: {ex.Message}");
+        }
+    }
+    
+    public async Task EditGameServer(GameServerObject jsonObject, string sessionId)
+    {
+        // Create a StringContent with the JSON data and set the content type
+        string jsonData = JsonConvert.SerializeObject(jsonObject);
+        string endpoint = $"editGameServer/{sessionId}";
+
+        try
+        {
+            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            Console.WriteLine($"Game server successfully edited in monitoring.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error editing the game server in monitoring: {ex.Message}");
+        }
+    }
+    
+    public async Task<string> GetGameServerAsync(string server)
+    {
+        // Define the endpoint for retrieving a game server with the sessionID
+        string endpoint = $"listGameServers/{server}";
+
+        try
+        {
+            string decryptedData = await _apiClient.ReceiveAndDecryptAsync(endpoint);
+            Console.WriteLine($"Game server for {server} retrieved successfully from monitoring.");
+            return decryptedData;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error retrieving the game server from monitoring: {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/EchoRelay.Core/Monitoring/GameServerObject.cs
+++ b/EchoRelay.Core/Monitoring/GameServerObject.cs
@@ -4,24 +4,22 @@ namespace EchoRelay.Core.Monitoring;
 
 public class GameServerObject
 {
-    public string? ServerIp { get; set; }
-
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "serverIP")]
-    public string? Region { get; set; }
-
+    public string? ServerIp { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "region")]
-    public string? Level { get; set; }
+    public string? Region { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "level")]
-    public string? GameMode { get; set; }
+    public string? Level { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "gameMode")]
-    public int PlayerCount { get; set; }
+    public string? GameMode { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "playerCount")]
-    public bool Assigned { get; set; }
-
+    public int PlayerCount { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "assigned")]
-    public string? SessionId { get; set; }
+    public bool Assigned { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "sessionID")]
-    public ulong GameServerId { get; set; }
+    public string? SessionId { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "gameServerID")]
+    public ulong GameServerId { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "public")]
     public bool @Public { get; set; }
 }

--- a/EchoRelay.Core/Monitoring/GameServerObject.cs
+++ b/EchoRelay.Core/Monitoring/GameServerObject.cs
@@ -1,0 +1,12 @@
+﻿namespace EchoRelay.Core.Monitoring;
+
+public class GameServerObject
+{
+    public string serverIP { get; set; }
+    public string region { get; set; }
+    public string type { get; set; }
+    public string gameMode { get; set; }
+    public int playerCount { get; set; }
+    public string sessionID { get; set; }
+    public bool @public { get; set; }
+}

--- a/EchoRelay.Core/Monitoring/GameServerObject.cs
+++ b/EchoRelay.Core/Monitoring/GameServerObject.cs
@@ -4,21 +4,24 @@ namespace EchoRelay.Core.Monitoring;
 
 public class GameServerObject
 {
-    public string serverIP { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string region { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string level { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string gameMode { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public int playerCount { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public bool assigned { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string sessionID { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public ulong gameServerID { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public bool @public { get; set; }
+    public string? ServerIp { get; set; }
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "serverIP")]
+    public string? Region { get; set; }
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "region")]
+    public string? Level { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "level")]
+    public string? GameMode { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "gameMode")]
+    public int PlayerCount { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "playerCount")]
+    public bool Assigned { get; set; }
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "assigned")]
+    public string? SessionId { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "sessionID")]
+    public ulong GameServerId { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "gameServerID")]
+    public bool @Public { get; set; }
 }

--- a/EchoRelay.Core/Monitoring/PeerStats.cs
+++ b/EchoRelay.Core/Monitoring/PeerStats.cs
@@ -19,7 +19,7 @@ public class PeerStats
 
         try
         {
-            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            await _apiClient.PostMonitoringData(endpoint, jsonData);
             Console.WriteLine($"Peer stats successfully edited in monitoring.");
         }
         catch (Exception ex)

--- a/EchoRelay.Core/Monitoring/PeerStats.cs
+++ b/EchoRelay.Core/Monitoring/PeerStats.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+
+namespace EchoRelay.Core.Monitoring;
+
+public class PeerStats
+{
+    private readonly ApiClient _apiClient;
+
+    public PeerStats(ApiClient apiClient)
+    {
+        _apiClient = apiClient;
+    }
+
+    public async Task EditPeerStats(PeerStatsObject jsonObject, string server)
+    {
+        // Create a StringContent with the JSON data and set the content type
+        string jsonData = JsonConvert.SerializeObject(jsonObject);
+        string endpoint = $"updatePeerStats/{server}";
+
+        try
+        {
+            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            Console.WriteLine($"Peer stats successfully edited in monitoring.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error editing the Peer stats in monitoring: {ex.Message}");
+        }
+    }
+}

--- a/EchoRelay.Core/Monitoring/PeerStatsObject.cs
+++ b/EchoRelay.Core/Monitoring/PeerStatsObject.cs
@@ -2,23 +2,19 @@
 
 namespace EchoRelay.Core.Monitoring;
 
-public class GameServerObject
+public class PeerStatsObject
 {
     public string serverIP { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string region { get; set; }
+    public int gameServers { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string level { get; set; }
+    public int login { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string gameMode { get; set; }
+    public int matching { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public int playerCount { get; set; }
+    public int config { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public bool assigned { get; set; }
+    public int transaction { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string sessionID { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public ulong gameServerID { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public bool @public { get; set; }
+    public int serverdb { get; set; }
 }

--- a/EchoRelay.Core/Monitoring/PeerStatsObject.cs
+++ b/EchoRelay.Core/Monitoring/PeerStatsObject.cs
@@ -7,17 +7,17 @@ public class PeerStatsObject
     [JsonProperty(PropertyName = "serverIP")]
     public string? ServerIp { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "gameServers")]
-    public int? GameServers { get; set; } = 0;
+    public int? GameServers { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "login")]
-    public int? Login { get; set; } = 0;
+    public int? Login { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "matching")]
-    public int? Matching { get; set; } = 0;
+    public int? Matching { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "config")]
-    public int? Config { get; set; } = 0;
+    public int? Config { get; set; }
 
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "transaction")]
-    public int? Transaction { get; set; } = 0;
+    public int? Transaction { get; set; }
 
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "serverdb")]
-    public int? ServerDb { get; set; } = 0;
+    public int? ServerDb { get; set; }
 }

--- a/EchoRelay.Core/Monitoring/PeerStatsObject.cs
+++ b/EchoRelay.Core/Monitoring/PeerStatsObject.cs
@@ -4,17 +4,19 @@ namespace EchoRelay.Core.Monitoring;
 
 public class PeerStatsObject
 {
-    public string serverIP { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public int gameServers { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public int login { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public int matching { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public int config { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public int transaction { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public int serverdb { get; set; }
+    public string? ServerIp { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "gameServers")]
+    public int? GameServers { get; set; } = 0;
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "login")]
+    public int? Login { get; set; } = 0;
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "matching")]
+    public int? Matching { get; set; } = 0;
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "config")]
+    public int? Config { get; set; } = 0;
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "transaction")]
+    public int? Transaction { get; set; } = 0;
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "serverdb")]
+    public int? ServerDb { get; set; } = 0;
 }

--- a/EchoRelay.Core/Monitoring/PeerStatsObject.cs
+++ b/EchoRelay.Core/Monitoring/PeerStatsObject.cs
@@ -4,6 +4,7 @@ namespace EchoRelay.Core.Monitoring;
 
 public class PeerStatsObject
 {
+    [JsonProperty(PropertyName = "serverIP")]
     public string? ServerIp { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "gameServers")]
     public int? GameServers { get; set; } = 0;

--- a/EchoRelay.Core/Monitoring/Server.cs
+++ b/EchoRelay.Core/Monitoring/Server.cs
@@ -1,0 +1,81 @@
+﻿using Newtonsoft.Json;
+
+namespace EchoRelay.Core.Monitoring;
+
+public class Server
+{
+    private readonly ApiClient _apiClient;
+
+    public Server(ApiClient apiClient)
+    {
+        _apiClient = apiClient;
+    }
+
+    public async Task DeleteServerAsync(string server)
+    {
+        // Define the endpoint for deleting a game server with the server IP
+        string endpoint = $"deleteServer/{server}";
+
+        try
+        {
+            await _apiClient.DeleteAsync(endpoint);
+            Console.WriteLine($"Server {server} deleted successfully from monitoring.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error deleting the server from monitoring: {ex.Message}");
+        }
+    }
+
+    public async Task AddServerAsync(ServerObject jsonObject)
+    {
+        // Create a StringContent with the JSON data and set the content type
+        string jsonData = JsonConvert.SerializeObject(jsonObject);
+        string endpoint = "addServer/";
+
+        try
+        {
+            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            Console.WriteLine($"Server successfully added to monitoring.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error adding the server to monitoring: {ex.Message}");
+        }
+    }
+    
+    public async Task EditServer(ServerObject jsonObject, string server)
+    {
+        // Create a StringContent with the JSON data and set the content type
+        string jsonData = JsonConvert.SerializeObject(jsonObject);
+        string endpoint = $"editServer/{server}";
+
+        try
+        {
+            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            Console.WriteLine($"Game server successfully edited in monitoring.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error editing the game server in monitoring: {ex.Message}");
+        }
+    }
+    
+    public async Task<string> GetServerAsync(string server)
+    {
+        // Define the endpoint for retrieving a game server with the sessionID
+        string endpoint = $"listServers/";
+
+        try
+        {
+            string decryptedData = await _apiClient.ReceiveAndDecryptAsync(endpoint);
+            Console.WriteLine($"Server retrieved successfully from monitoring.");
+            return decryptedData;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error retrieving the server from monitoring: {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/EchoRelay.Core/Monitoring/Server.cs
+++ b/EchoRelay.Core/Monitoring/Server.cs
@@ -18,7 +18,7 @@ public class Server
 
         try
         {
-            await _apiClient.DeleteAsync(endpoint);
+            await _apiClient.DeleteMonitoringData(endpoint);
             Console.WriteLine($"Server {server} deleted successfully from monitoring.");
         }
         catch (Exception ex)
@@ -35,7 +35,7 @@ public class Server
 
         try
         {
-            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            await _apiClient.PostMonitoringData(endpoint, jsonData);
             Console.WriteLine($"Server successfully added to monitoring.");
         }
         catch (Exception ex)
@@ -52,30 +52,12 @@ public class Server
 
         try
         {
-            await _apiClient.EncryptAndSendAsync(endpoint, jsonData);
+            await _apiClient.PostMonitoringData(endpoint, jsonData);
             Console.WriteLine($"Game server successfully edited in monitoring.");
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Error editing the game server in monitoring: {ex.Message}");
-        }
-    }
-    
-    public async Task<string> GetServerAsync(string server)
-    {
-        // Define the endpoint for retrieving a game server with the sessionID
-        string endpoint = $"listServers/";
-
-        try
-        {
-            string decryptedData = await _apiClient.ReceiveAndDecryptAsync(endpoint);
-            Console.WriteLine($"Server retrieved successfully from monitoring.");
-            return decryptedData;
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error retrieving the server from monitoring: {ex.Message}");
-            return null;
         }
     }
 }

--- a/EchoRelay.Core/Monitoring/Server.cs
+++ b/EchoRelay.Core/Monitoring/Server.cs
@@ -53,7 +53,7 @@ public class Server
         try
         {
             await _apiClient.PostMonitoringData(endpoint, jsonData);
-            Console.WriteLine($"Game server successfully edited in monitoring.");
+            Console.WriteLine($"Server successfully edited in monitoring.");
         }
         catch (Exception ex)
         {

--- a/EchoRelay.Core/Monitoring/Server.cs
+++ b/EchoRelay.Core/Monitoring/Server.cs
@@ -48,7 +48,7 @@ public class Server
     {
         // Create a StringContent with the JSON data and set the content type
         string jsonData = JsonConvert.SerializeObject(jsonObject);
-        string endpoint = $"editServer/{server}";
+        string endpoint = $"updateServer/{server}";
 
         try
         {

--- a/EchoRelay.Core/Monitoring/ServerObject.cs
+++ b/EchoRelay.Core/Monitoring/ServerObject.cs
@@ -5,8 +5,8 @@ namespace EchoRelay.Core.Monitoring;
 
 public class ServerObject
 {
+    [JsonProperty(PropertyName = "ip")] 
     public string Ip { get; set; } = "";
-
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "apiservice_host")]
     public string? ApiServiceHost { get; set; }
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "configservice_host")]
@@ -20,6 +20,9 @@ public class ServerObject
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "transactionservice_host")]
     public string? TransactionServiceHost { get; set; }
     
+    [JsonProperty(PropertyName = "publisher_lock")]
     public string PublisherLock { get; set; } = "rad15_live";
+    
+    [JsonProperty(PropertyName = "online")] 
     public bool Online { get; set; } = false;
 }

--- a/EchoRelay.Core/Monitoring/ServerObject.cs
+++ b/EchoRelay.Core/Monitoring/ServerObject.cs
@@ -5,20 +5,21 @@ namespace EchoRelay.Core.Monitoring;
 
 public class ServerObject
 {
-    public string ip { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] 
-    public string apiservice_host { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string configservice_host { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] 
-    public string loginservice_host { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string matchingservice_host { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string serverdb_host { get; set; }
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public string transactionservice_host { get; set; }
+    public string Ip { get; set; } = "";
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "apiservice_host")]
+    public string? ApiServiceHost { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "configservice_host")]
+    public string? ConfigServiceHost { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "loginservice_host")]
+    public string? LoginServiceHost { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "matchingservice_host")]
+    public string? MatchingServiceHost { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "serverdb_host")]
+    public string? ServerDbHost { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "transactionservice_host")]
+    public string? TransactionServiceHost { get; set; }
     
-    public string publisher_lock { get; set; } = "rad15_live";
-    public bool online { get; set; } = false;
+    public string PublisherLock { get; set; } = "rad15_live";
+    public bool Online { get; set; } = false;
 }

--- a/EchoRelay.Core/Monitoring/ServerObject.cs
+++ b/EchoRelay.Core/Monitoring/ServerObject.cs
@@ -1,15 +1,24 @@
 ﻿using EchoRelay.Core.Game;
+using Newtonsoft.Json;
 
 namespace EchoRelay.Core.Monitoring;
 
 public class ServerObject
 {
     public string ip { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] 
     public string apiservice_host { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public string configservice_host { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] 
     public string loginservice_host { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public string matchingservice_host { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public string serverdb_host { get; set; }
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public string transactionservice_host { get; set; }
+    
     public string publisher_lock { get; set; } = "rad15_live";
+    public bool online { get; set; } = false;
 }

--- a/EchoRelay.Core/Monitoring/ServerObject.cs
+++ b/EchoRelay.Core/Monitoring/ServerObject.cs
@@ -1,0 +1,15 @@
+﻿using EchoRelay.Core.Game;
+
+namespace EchoRelay.Core.Monitoring;
+
+public class ServerObject
+{
+    public string ip { get; set; }
+    public string apiservice_host { get; set; }
+    public string configservice_host { get; set; }
+    public string loginservice_host { get; set; }
+    public string matchingservice_host { get; set; }
+    public string serverdb_host { get; set; }
+    public string transactionservice_host { get; set; }
+    public string publisher_lock { get; set; } = "rad15_live";
+}

--- a/EchoRelay.Core/Server/Server.cs
+++ b/EchoRelay.Core/Server/Server.cs
@@ -194,6 +194,7 @@ namespace EchoRelay.Core.Server
         /// <exception cref="InvalidOperationException">An exception thrown if the server is already started when this method is called.</exception>
         public async Task Start(CancellationTokenSource? cancellationTokenSource = null)
         {
+            Console.WriteLine("Starting server...");
             // If we are running already, throw an exception.
             if (Running)
             {
@@ -220,6 +221,17 @@ namespace EchoRelay.Core.Server
             // Fire our started event
             OnServerStarted?.Invoke(this);
 
+            ServerObject server = new ServerObject();
+            ServiceConfig serviceConfig = Settings.GenerateServiceConfig(PublicIPAddress?.ToString() ?? "localhost");
+            server.apiservice_host = serviceConfig.ApiServiceHost;
+            server.loginservice_host = serviceConfig.LoginServiceHost;
+            server.configservice_host = serviceConfig.ConfigServiceHost;
+            server.matchingservice_host = serviceConfig.MatchingServiceHost;
+            server.serverdb_host = serviceConfig.ServerDBServiceHost;
+            server.transactionservice_host = serviceConfig.TransactionServiceHost;
+            server.ip = PublicIPAddress.ToString();
+            await apiManager.Server.AddServerAsync(server);
+            
             // Enter a loop to accept new web socket connections.
             try
             {
@@ -299,17 +311,6 @@ namespace EchoRelay.Core.Server
 
             // Fire our stopped event
             OnServerStopped?.Invoke(this);
-            
-            ServerObject server = new ServerObject();
-            ServiceConfig serviceConfig = Settings.GenerateServiceConfig(PublicIPAddress?.ToString() ?? "localhost");
-            server.apiservice_host = serviceConfig.ApiServiceHost;
-            server.loginservice_host = serviceConfig.LoginServiceHost;
-            server.configservice_host = serviceConfig.ConfigServiceHost;
-            server.matchingservice_host = serviceConfig.MatchingServiceHost;
-            server.serverdb_host = serviceConfig.ServerDBServiceHost;
-            server.transactionservice_host = serviceConfig.TransactionServiceHost;
-            server.ip = PublicIPAddress.ToString();
-            await apiManager.Server.AddServerAsync(server);
         }
 
         /// <summary>

--- a/EchoRelay.Core/Server/Server.cs
+++ b/EchoRelay.Core/Server/Server.cs
@@ -181,7 +181,8 @@ namespace EchoRelay.Core.Server
                 { Settings.TransactionServicePath.ToLower(), TransactionService },
             }.AsReadOnly();
             
-            apiManager = new ApiManager();
+            apiManager = ApiManager.Instance;
+
         }
         #endregion
 

--- a/EchoRelay.Core/Server/Server.cs
+++ b/EchoRelay.Core/Server/Server.cs
@@ -224,16 +224,16 @@ namespace EchoRelay.Core.Server
 
             ServerObject server = new ServerObject();
             ServiceConfig serviceConfig = Settings.GenerateServiceConfig(PublicIPAddress?.ToString() ?? "localhost");
-            server.apiservice_host = serviceConfig.ApiServiceHost;
-            server.loginservice_host = serviceConfig.LoginServiceHost;
-            server.configservice_host = serviceConfig.ConfigServiceHost;
-            server.matchingservice_host = serviceConfig.MatchingServiceHost;
-            server.serverdb_host = serviceConfig.ServerDBServiceHost;
-            server.transactionservice_host = serviceConfig.TransactionServiceHost;
-            server.ip = PublicIPAddress.ToString();
-            server.online = true;
-            apiManager.Server.EditServer(server, server.ip);
-            
+            server.ApiServiceHost = serviceConfig.ApiServiceHost;
+            server.LoginServiceHost = serviceConfig.LoginServiceHost;
+            server.ConfigServiceHost = serviceConfig.ConfigServiceHost;
+            server.MatchingServiceHost = serviceConfig.MatchingServiceHost;
+            server.ServerDbHost = serviceConfig.ServerDBServiceHost;
+            server.TransactionServiceHost = serviceConfig.TransactionServiceHost;
+            server.Ip = PublicIPAddress?.ToString() ?? "localhost";
+            server.Online = true;
+            _ = Task.Run(() => apiManager?.Server.EditServer(server, server.Ip));
+
             // Enter a loop to accept new web socket connections.
             try
             {
@@ -322,9 +322,9 @@ namespace EchoRelay.Core.Server
         public async void Stop()
         {
             ServerObject server = new ServerObject();
-            server.ip = PublicIPAddress.ToString();
-            server.online = false;
-            apiManager.Server.EditServer(server, server.ip);
+            server.Ip = PublicIPAddress?.ToString() ?? "localhost";
+            server.Online = false;
+            _ = Task.Run(() => apiManager?.Server.EditServer(server, server.Ip));            
             // Cancel any cancellation token we have now.
             _cancellationTokenSource?.Cancel();
         }

--- a/EchoRelay.Core/Server/Server.cs
+++ b/EchoRelay.Core/Server/Server.cs
@@ -230,7 +230,8 @@ namespace EchoRelay.Core.Server
             server.serverdb_host = serviceConfig.ServerDBServiceHost;
             server.transactionservice_host = serviceConfig.TransactionServiceHost;
             server.ip = PublicIPAddress.ToString();
-            await apiManager.Server.AddServerAsync(server);
+            server.online = true;
+            apiManager.Server.EditServer(server, server.ip);
             
             // Enter a loop to accept new web socket connections.
             try
@@ -319,7 +320,10 @@ namespace EchoRelay.Core.Server
         /// </summary>
         public async void Stop()
         {
-            await apiManager.Server.DeleteServerAsync(PublicIPAddress.ToString());
+            ServerObject server = new ServerObject();
+            server.ip = PublicIPAddress.ToString();
+            server.online = false;
+            apiManager.Server.EditServer(server, server.ip);
             // Cancel any cancellation token we have now.
             _cancellationTokenSource?.Cancel();
         }

--- a/EchoRelay.Core/Server/Server.cs
+++ b/EchoRelay.Core/Server/Server.cs
@@ -223,7 +223,7 @@ namespace EchoRelay.Core.Server
             OnServerStarted?.Invoke(this);
 
             ServerObject server = new ServerObject();
-            ServiceConfig serviceConfig = Settings.GenerateServiceConfig(PublicIPAddress?.ToString() ?? "localhost");
+            ServiceConfig serviceConfig = Settings.GenerateServiceConfig(PublicIPAddress?.ToString() ?? "localhost", apiKey:false);
             server.ApiServiceHost = serviceConfig.ApiServiceHost;
             server.LoginServiceHost = serviceConfig.LoginServiceHost;
             server.ConfigServiceHost = serviceConfig.ConfigServiceHost;
@@ -324,7 +324,15 @@ namespace EchoRelay.Core.Server
             ServerObject server = new ServerObject();
             server.Ip = PublicIPAddress?.ToString() ?? "localhost";
             server.Online = false;
-            _ = Task.Run(() => apiManager?.Server.EditServer(server, server.Ip));            
+            _ = Task.Run(() => apiManager?.Server.EditServer(server, server.Ip));  
+            apiManager.peerStatsObject.ServerIp = PublicIPAddress?.ToString();
+            apiManager.peerStatsObject.Login = 0;
+            apiManager.peerStatsObject.Matching = 0;
+            apiManager.peerStatsObject.Config = 0;
+            apiManager.peerStatsObject.Transaction = 0;
+            apiManager.peerStatsObject.ServerDb = 0;
+            await apiManager.PeerStats.EditPeerStats(apiManager.peerStatsObject,
+                    PublicIPAddress?.ToString() ?? "localhost");
             // Cancel any cancellation token we have now.
             _cancellationTokenSource?.Cancel();
         }

--- a/EchoRelay.Core/Server/ServerSettings.cs
+++ b/EchoRelay.Core/Server/ServerSettings.cs
@@ -111,15 +111,19 @@ namespace EchoRelay.Core.Server
         /// <param name="address">The address or domain to use for the base URL for all host endpoints.</param>
         /// <param name="serverConfig">Indicates whether sensitive gameserver-only fields should be included in the config.</param>
         /// <param name="publisherLock">The publisher/environment lock to generate with.</param>
+        /// <param name="apiKey">Used to generate a config without API key</param>
+
         /// <returns>Returns the generated <see cref="ServiceConfig"/>.</returns>
-        public ServiceConfig GenerateServiceConfig(string address, bool serverConfig = true, string publisherLock = "rad15_live", string? serverPlugin = null)
+        public ServiceConfig GenerateServiceConfig(string address, bool serverConfig = true, string publisherLock = "rad15_live", string? serverPlugin = null, bool? apiKey = null)
         {
             // Obtain our base host
             string webSocketHost = $"ws://{address}:{Port}";
             string httpHost = $"http://{address}:{Port}";
+            string serverDBHostNoKey;
 
             // Construct our ServerDB path
             string serverDBHost = webSocketHost + ServerDBServicePath;
+            serverDBHostNoKey = serverDBHost;
             if (ServerDBApiKey != null)
             {
                 serverDBHost += $"?api_key={HttpUtility.UrlEncode(ServerDBApiKey)}";
@@ -131,7 +135,7 @@ namespace EchoRelay.Core.Server
                 configServiceHost: webSocketHost + ConfigServicePath,
                 loginServiceHost: webSocketHost + LoginServicePath + $"?auth=AccountPassword&displayname=AccountName",
                 matchingServiceHost: webSocketHost + MatchingServicePath,
-                serverdbServiceHost: serverConfig ? serverDBHost : null,
+                serverdbServiceHost: apiKey == null ? (serverConfig ? serverDBHost : null) : serverDBHostNoKey,
                 transactionServiceHost: webSocketHost + TransactionServicePath,
                 publisherLock: publisherLock,
                 serverPlugin: serverPlugin

--- a/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
@@ -38,7 +38,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
         {
             RegisteredGameServers = new ConcurrentDictionary<ulong, RegisteredGameServer>();
             RegisteredGameServersBySessionId = new ConcurrentDictionary<Guid, RegisteredGameServer>();
-            apiManager = new ApiManager();
+            apiManager = ApiManager.Instance;
         }
         #endregion
 

--- a/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
@@ -54,13 +54,13 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             
             GameServerObject gameServerObject = new GameServerObject();
             gameServerObject.ServerIp = registeredGameServer.Server.PublicIPAddress?.ToString();
-            gameServerObject.Region = registeredGameServer.RegionSymbol.ToString();
+            gameServerObject.Region = "";
             gameServerObject.SessionId = registeredGameServer.SessionId.ToString();
             gameServerObject.GameServerId = registeredGameServer.ServerId;
             gameServerObject.Assigned = false;
-            gameServerObject.GameMode = registeredGameServer.SessionGameTypeSymbol.ToString();
-            gameServerObject.Public = registeredGameServer.SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
-            gameServerObject.Level = registeredGameServer.SessionLevelSymbol.ToString();
+            gameServerObject.GameMode = "";
+            gameServerObject.Public = registeredGameServer.SessionLobbyType == LobbyType.Public;
+            gameServerObject.Level = "";
             gameServerObject.PlayerCount = registeredGameServer.SessionPlayerCount;
             Task.Run(() => apiManager.GameServer.AddGameServerAsync(gameServerObject));
             return registeredGameServer;

--- a/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
@@ -53,16 +53,16 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             OnGameServerRegistered?.Invoke(registeredGameServer);
             
             GameServerObject gameServerObject = new GameServerObject();
-            gameServerObject.serverIP = registeredGameServer.Server.PublicIPAddress.ToString();
-            gameServerObject.region = registeredGameServer.RegionSymbol.ToString();
-            gameServerObject.sessionID = registeredGameServer.SessionId.ToString();
-            gameServerObject.gameServerID = registeredGameServer.ServerId;
-            gameServerObject.assigned = false;
-            gameServerObject.gameMode = registeredGameServer.SessionGameTypeSymbol.ToString();
-            gameServerObject.@public = registeredGameServer.SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
-            gameServerObject.level = registeredGameServer.SessionLevelSymbol.ToString();
-            gameServerObject.playerCount = registeredGameServer.SessionPlayerCount;
-            apiManager.GameServer.AddGameServerAsync(gameServerObject);
+            gameServerObject.ServerIp = registeredGameServer.Server.PublicIPAddress?.ToString();
+            gameServerObject.Region = registeredGameServer.RegionSymbol.ToString();
+            gameServerObject.SessionId = registeredGameServer.SessionId.ToString();
+            gameServerObject.GameServerId = registeredGameServer.ServerId;
+            gameServerObject.Assigned = false;
+            gameServerObject.GameMode = registeredGameServer.SessionGameTypeSymbol.ToString();
+            gameServerObject.Public = registeredGameServer.SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
+            gameServerObject.Level = registeredGameServer.SessionLevelSymbol.ToString();
+            gameServerObject.PlayerCount = registeredGameServer.SessionPlayerCount;
+            Task.Run(() => apiManager.GameServer.AddGameServerAsync(gameServerObject));
             return registeredGameServer;
         }
 
@@ -80,7 +80,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
 
         public void RemoveGameServer(RegisteredGameServer registeredGameServer)
         {
-            apiManager.GameServer.DeleteGameServerAsync(registeredGameServer.ServerId.ToString());
+            Task.Run(() => apiManager.GameServer.DeleteGameServerAsync(registeredGameServer.ServerId.ToString()));
             RemoveGameServer(registeredGameServer.ServerId);
         }
         public void RemoveGameServer(ulong serverId)

--- a/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
@@ -2,6 +2,7 @@
 using EchoRelay.Core.Server.Messages.ServerDB;
 using EchoRelay.Core.Utils;
 using System.Collections.Concurrent;
+using EchoRelay.Core.Monitoring;
 using static EchoRelay.Core.Server.Messages.ServerDB.ERGameServerStartSession;
 
 namespace EchoRelay.Core.Server.Services.ServerDB
@@ -28,6 +29,8 @@ namespace EchoRelay.Core.Server.Services.ServerDB
         /// Event of a game server being unregistered.
         /// </summary>
         public event GameServerRegistrationChangedEventHandler? OnGameServerUnregistered;
+
+        public ApiManager apiManager;
         #endregion
 
         #region Constructor
@@ -35,6 +38,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
         {
             RegisteredGameServers = new ConcurrentDictionary<ulong, RegisteredGameServer>();
             RegisteredGameServersBySessionId = new ConcurrentDictionary<Guid, RegisteredGameServer>();
+            apiManager = new ApiManager();
         }
         #endregion
 
@@ -43,9 +47,22 @@ namespace EchoRelay.Core.Server.Services.ServerDB
         {
             // Add the game server to our lookup
             RegisteredGameServers[registeredGameServer.ServerId] = registeredGameServer;
+            
 
             // Fire the relevant event for the game server being registered.
             OnGameServerRegistered?.Invoke(registeredGameServer);
+            
+            GameServerObject gameServerObject = new GameServerObject();
+            gameServerObject.serverIP = registeredGameServer.Server.PublicIPAddress.ToString();
+            gameServerObject.region = registeredGameServer.RegionSymbol.ToString();
+            gameServerObject.sessionID = registeredGameServer.SessionId.ToString();
+            gameServerObject.gameServerID = registeredGameServer.ServerId;
+            gameServerObject.assigned = false;
+            gameServerObject.gameMode = registeredGameServer.SessionGameTypeSymbol.ToString();
+            gameServerObject.@public = registeredGameServer.SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
+            gameServerObject.level = registeredGameServer.SessionLevelSymbol.ToString();
+            gameServerObject.playerCount = registeredGameServer.SessionPlayerCount;
+            apiManager.GameServer.AddGameServerAsync(gameServerObject);
             return registeredGameServer;
         }
 
@@ -63,6 +80,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
 
         public void RemoveGameServer(RegisteredGameServer registeredGameServer)
         {
+            apiManager.GameServer.DeleteGameServerAsync(registeredGameServer.ServerId.ToString());
             RemoveGameServer(registeredGameServer.ServerId);
         }
         public void RemoveGameServer(ulong serverId)

--- a/EchoRelay.Core/Server/Services/ServerDB/RegisteredGameServer.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/RegisteredGameServer.cs
@@ -294,7 +294,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
 
             GameServerObject gameServerObject = new GameServerObject();
             gameServerObject.ServerIp = Server.PublicIPAddress?.ToString();
-            gameServerObject.Region = Server.SymbolCache.GetName(RegionSymbol);;
+            gameServerObject.Region = Server.SymbolCache.GetName(RegionSymbol);
             gameServerObject.SessionId = SessionId.ToString();
             gameServerObject.Assigned = true;
             gameServerObject.GameServerId = ServerId;

--- a/EchoRelay.Core/Server/Services/ServerDB/RegisteredGameServer.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/RegisteredGameServer.cs
@@ -24,7 +24,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
         /// </summary>
         private GameServerRegistry Registry { get; }
         
-        public ApiManager ApiManager { get; }
+        public ApiManager apiManager { get; }
 
         /// <summary>
         /// The registration request provided by the game server initially.
@@ -206,7 +206,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             SessionPlayerLimits = GameTypePlayerLimits.DefaultLimits;
             _playerSessions = new Dictionary<Guid, (Peer, TeamIndex)>();
             _accessLock = new AsyncLock();
-            ApiManager = new ApiManager();
+            apiManager = ApiManager.Instance;
         }
         #endregion
 
@@ -294,15 +294,15 @@ namespace EchoRelay.Core.Server.Services.ServerDB
 
             GameServerObject gameServerObject = new GameServerObject();
             gameServerObject.serverIP = Server.PublicIPAddress.ToString();
-            gameServerObject.region = RegionSymbol.ToString();
+            gameServerObject.region = Server.SymbolCache.GetName(RegionSymbol);;
             gameServerObject.sessionID = SessionId.ToString();
             gameServerObject.assigned = true;
             gameServerObject.gameServerID = ServerId;
-            gameServerObject.gameMode = SessionGameTypeSymbol.ToString();
+            gameServerObject.gameMode = Server.SymbolCache.GetName(SessionGameTypeSymbol.Value);
             gameServerObject.@public = SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
-            gameServerObject.level = SessionLevelSymbol.ToString();
+            gameServerObject.level = Server.SymbolCache.GetName(SessionLevelSymbol.Value);
             gameServerObject.playerCount = SessionPlayerCount;
-            ApiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
+            apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
             
             // Add the new session id to the parent registry's lookup.
             Registry.RegisteredGameServersBySessionId[SessionId.Value] = this;
@@ -532,15 +532,9 @@ namespace EchoRelay.Core.Server.Services.ServerDB
                 OnPlayersAdded?.Invoke(this, addedPlayersInfo);
                 GameServerObject gameServerObject = new GameServerObject();
                 gameServerObject.serverIP = Server.PublicIPAddress.ToString();
-                gameServerObject.region = RegionSymbol.ToString();
-                gameServerObject.sessionID = SessionId.ToString();
                 gameServerObject.assigned = true;
-                gameServerObject.gameServerID = ServerId;
-                gameServerObject.gameMode = SessionGameTypeSymbol.ToString();
-                gameServerObject.@public = SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
-                gameServerObject.level = SessionLevelSymbol.ToString();
                 gameServerObject.playerCount = SessionPlayerCount;
-                ApiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
+                apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
             }
         }
 
@@ -576,15 +570,9 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             OnPlayerRemoved?.Invoke(this, playerSession, peer); 
             GameServerObject gameServerObject = new GameServerObject();
             gameServerObject.serverIP = Server.PublicIPAddress.ToString();
-            gameServerObject.region = RegionSymbol.ToString();
-            gameServerObject.sessionID = SessionId.ToString();
             gameServerObject.assigned = true;
-            gameServerObject.gameServerID = ServerId;
-            gameServerObject.gameMode = SessionGameTypeSymbol.ToString();
-            gameServerObject.@public = SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
-            gameServerObject.level = SessionLevelSymbol.ToString();
             gameServerObject.playerCount = SessionPlayerCount;
-            ApiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
+            apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
         }
 
         public async Task EndSession()
@@ -618,7 +606,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             gameServerObject.level = "";
             gameServerObject.playerCount = SessionPlayerCount;
             
-            ApiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
+            apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
 
         }
         #endregion

--- a/EchoRelay.Core/Server/Services/ServerDB/RegisteredGameServer.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/RegisteredGameServer.cs
@@ -293,17 +293,17 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             await Peer.Send(new ERGameServerStartSession(SessionId.Value, SessionChannel.Value, (byte)SessionPlayerLimits.TotalPlayerLimit, SessionLobbyType, mergedSessionSettings, entrantDescriptors.ToArray()));
 
             GameServerObject gameServerObject = new GameServerObject();
-            gameServerObject.serverIP = Server.PublicIPAddress.ToString();
-            gameServerObject.region = Server.SymbolCache.GetName(RegionSymbol);;
-            gameServerObject.sessionID = SessionId.ToString();
-            gameServerObject.assigned = true;
-            gameServerObject.gameServerID = ServerId;
-            gameServerObject.gameMode = Server.SymbolCache.GetName(SessionGameTypeSymbol.Value);
-            gameServerObject.@public = SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
-            gameServerObject.level = Server.SymbolCache.GetName(SessionLevelSymbol.Value);
-            gameServerObject.playerCount = SessionPlayerCount;
-            apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
-            
+            gameServerObject.ServerIp = Server.PublicIPAddress?.ToString();
+            gameServerObject.Region = Server.SymbolCache.GetName(RegionSymbol);;
+            gameServerObject.SessionId = SessionId.ToString();
+            gameServerObject.Assigned = true;
+            gameServerObject.GameServerId = ServerId;
+            gameServerObject.GameMode = Server.SymbolCache.GetName(SessionGameTypeSymbol.Value);
+            gameServerObject.Public = SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
+            gameServerObject.Level = Server.SymbolCache.GetName(SessionLevelSymbol.Value);
+            gameServerObject.PlayerCount = SessionPlayerCount;
+            _ = Task.Run(() => apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString()));
+
             // Add the new session id to the parent registry's lookup.
             Registry.RegisteredGameServersBySessionId[SessionId.Value] = this;
         }
@@ -531,10 +531,11 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             {
                 OnPlayersAdded?.Invoke(this, addedPlayersInfo);
                 GameServerObject gameServerObject = new GameServerObject();
-                gameServerObject.serverIP = Server.PublicIPAddress.ToString();
-                gameServerObject.assigned = true;
-                gameServerObject.playerCount = SessionPlayerCount;
-                apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
+                gameServerObject.ServerIp = Server.PublicIPAddress?.ToString();
+                gameServerObject.Assigned = true;
+                gameServerObject.PlayerCount = SessionPlayerCount;
+                _ = Task.Run(() => apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString()));
+                
             }
         }
 
@@ -569,10 +570,10 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             // Fire the event for a player being removed
             OnPlayerRemoved?.Invoke(this, playerSession, peer); 
             GameServerObject gameServerObject = new GameServerObject();
-            gameServerObject.serverIP = Server.PublicIPAddress.ToString();
-            gameServerObject.assigned = true;
-            gameServerObject.playerCount = SessionPlayerCount;
-            apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
+            gameServerObject.ServerIp = Server.PublicIPAddress?.ToString();
+            gameServerObject.Assigned = true;
+            gameServerObject.PlayerCount = SessionPlayerCount;
+            _ = Task.Run(() => apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString()));
         }
 
         public async Task EndSession()
@@ -596,17 +597,17 @@ namespace EchoRelay.Core.Server.Services.ServerDB
             OnSessionStateChanged?.Invoke(this);
             
             GameServerObject gameServerObject = new GameServerObject();
-            gameServerObject.serverIP = Server.PublicIPAddress.ToString();
-            gameServerObject.region = RegionSymbol.ToString();
-            gameServerObject.sessionID = "";
-            gameServerObject.assigned = false;
-            gameServerObject.gameServerID = ServerId;
-            gameServerObject.gameMode = "";
-            gameServerObject.@public = SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
-            gameServerObject.level = "";
-            gameServerObject.playerCount = SessionPlayerCount;
+            gameServerObject.ServerIp = Server.PublicIPAddress?.ToString();
+            gameServerObject.Region = RegionSymbol.ToString();
+            gameServerObject.SessionId = "";
+            gameServerObject.Assigned = false;
+            gameServerObject.GameServerId = ServerId;
+            gameServerObject.GameMode = "";
+            gameServerObject.Public = SessionLobbyType == ERGameServerStartSession.LobbyType.Public;
+            gameServerObject.Level = "";
+            gameServerObject.PlayerCount = SessionPlayerCount;
             
-            apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString());
+            _ = Task.Run(() => apiManager.GameServer.EditGameServer(gameServerObject, ServerId.ToString()));
 
         }
         #endregion


### PR DESCRIPTION
Not finished, should be done tomorrow

This PR is made to add monitoring of the servers/game servers from relay data, calls are being made on different events being triggered by relay, the API code is [here](https://github.com/NotBlue-Dev/MonitoringAPIEchoVR)

The idea is to have a centralized server that hold the servers stats allowing server browser and owner to manage / join server in an easy way, to see what the API expose and the different endpoints you can check the repo I linked

The server is already up and running with the latest API version

http://51.75.140.182:3000/api/listServers