### PR TITLE
Add region based privates.

### DIFF
--- a/EchoRelay.Core/Server/Messages/Matching/LobbyCreateSessionRequestv9.cs
+++ b/EchoRelay.Core/Server/Messages/Matching/LobbyCreateSessionRequestv9.cs
@@ -17,8 +17,10 @@ namespace EchoRelay.Core.Server.Messages.Matching
         /// </summary>
         public override long MessageTypeSymbol => 6456590782678944787;
 
-        // TODO
-        public ulong Unk0;
+        /// <summary>
+        ///  A symbol representing the region requested for the session.
+        /// </summary>
+        public long RegionSymbol;
 
         /// <summary>
         /// The version of the client, prevents mismatches in matching.
@@ -81,7 +83,7 @@ namespace EchoRelay.Core.Server.Messages.Matching
         /// </summary>
         public LobbyCreateSessionRequestv9()
         {
-            Unk0 = 0;
+            RegionSymbol = 0;
             VersionLock = 0;
             GameTypeSymbol = -1;
             LevelSymbol = -1;
@@ -104,7 +106,7 @@ namespace EchoRelay.Core.Server.Messages.Matching
         /// <param name="io">The stream to read/write data from/to.</param>
         public override void Stream(StreamIO io)
         {
-            io.Stream(ref Unk0);
+            io.Stream(ref RegionSymbol);
             io.Stream(ref VersionLock);
             io.Stream(ref GameTypeSymbol);
             io.Stream(ref LevelSymbol);
@@ -133,7 +135,7 @@ namespace EchoRelay.Core.Server.Messages.Matching
         public override string ToString()
         {
             return $"{GetType().Name}(" +
-                $"unk0={Unk0}, " +
+                $"RegionSymbol={RegionSymbol}, " +
                 $"version_lock={VersionLock}, " +
                 $"game_type={GameTypeSymbol}, " +
                 $"level={LevelSymbol}, " +

--- a/EchoRelay.Core/Server/Messages/ServerDB/ERGameServerRegistrationRequest.cs
+++ b/EchoRelay.Core/Server/Messages/ServerDB/ERGameServerRegistrationRequest.cs
@@ -57,8 +57,8 @@ namespace EchoRelay.Core.Server.Messages.ServerDB
             io.Stream(ref ServerId);
             io.Stream(ref InternalAddress, ByteOrder.BigEndian);
             io.Stream(ref Port);
-            ushort pad2 = 0; // 2 bytes of padding
-            io.Stream(ref pad2);
+            byte[] pad10 = new byte[10]; // Was 2 bytes, but we need 10 bytes to align with the server's struct.
+            io.Stream(ref pad10);
             io.Stream(ref RegionSymbol);
             io.Stream(ref VersionLock);
         }

--- a/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
+++ b/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
@@ -60,7 +60,7 @@ namespace EchoRelay.Core.Server.Services.Matching
         private async Task ProcessCreateSessionRequestv9(Peer sender, LobbyCreateSessionRequestv9 request)
         {
             // Set the matching data for our user to provide context to matching operations moving forward.
-            sender.SetSessionData(MatchingSession.FromCreateSessionCriteria(request.UserId, request.ChannelUUID, request.GameTypeSymbol, request.LevelSymbol, request.LobbyType, (TeamIndex)request.TeamIndex, request.SessionSettings));
+            sender.SetSessionData(MatchingSession.FromCreateSessionCriteria(request.UserId, request.ChannelUUID, request.GameTypeSymbol, request.LevelSymbol, request.LobbyType, (TeamIndex)request.TeamIndex, request.SessionSettings,request.RegionSymbol));
 
             // Process the underlying request.
             await ProcessMatchingSession(sender, request.Session, request.UserId);
@@ -176,6 +176,10 @@ namespace EchoRelay.Core.Server.Services.Matching
             // This is a create lobby, or find lobby request. We will try to find an existing server that matches the request.
             // Filter game servers, produce ping request endpoint data.
             // We limit the amount to 100, to avoid the response hitting the max packet size.
+            if(matchingSession.RegionSymbol != null)
+            {
+                Console.Write(matchingSession.RegionSymbol);
+            }
             var gameServers = Server.ServerDBService.Registry.FilterGameServers(
                 findMax: 100,
                 sessionId: matchingSession.LobbyId,
@@ -185,7 +189,8 @@ namespace EchoRelay.Core.Server.Services.Matching
                 locked: false,
                 lobbyTypes: matchingSession.SearchLobbyTypes,
                 requestedTeam: matchingSession.TeamIndex,
-                unfilledServerOnly: true
+                unfilledServerOnly: true,
+                regionSymbol: matchingSession.RegionSymbol
             );
 
             // If we only have one game server, immediately connect the peer. Otherwise, perform a ping request to determine the lowest ping server.

--- a/EchoRelay.Core/Server/Services/Matching/MatchingSession.cs
+++ b/EchoRelay.Core/Server/Services/Matching/MatchingSession.cs
@@ -34,9 +34,11 @@ namespace EchoRelay.Core.Server.Services.Matching
         public ERGameServerStartSession.SessionSettings SessionSettings { get; private set; }
         public TeamIndex TeamIndex { get; private set; }
 
+        public long? RegionSymbol { get; private set; }
+
         public RegisteredGameServer? MatchedGameServer { get; set; }
         public Guid? MatchedSessionId { get; set; }
-        private MatchingSession(XPlatformId userId, Guid? lobbyId, Guid? channel, long? gameTypeSymbol, long? levelSymbol, LobbyType newSessionLobbyType, TeamIndex teamIndex, ERGameServerStartSession.SessionSettings sessionSettings)
+        private MatchingSession(XPlatformId userId, Guid? lobbyId, Guid? channel, long? gameTypeSymbol, long? levelSymbol, LobbyType newSessionLobbyType, TeamIndex teamIndex, ERGameServerStartSession.SessionSettings sessionSettings, Int64? regionSymbol = null)
         {
             UserId = userId;
             LobbyId = lobbyId;
@@ -46,11 +48,12 @@ namespace EchoRelay.Core.Server.Services.Matching
             NewSessionLobbyType = newSessionLobbyType;
             TeamIndex = teamIndex;
             SessionSettings = sessionSettings;
+            RegionSymbol = regionSymbol;
         }
 
-        public static MatchingSession FromCreateSessionCriteria(XPlatformId userId, Guid? channel, long? gameTypeSymbol, long? levelSymbol, LobbyType lobbyType, TeamIndex teamIndex, ERGameServerStartSession.SessionSettings sessionSettings)
+        public static MatchingSession FromCreateSessionCriteria(XPlatformId userId, Guid? channel, long? gameTypeSymbol, long? levelSymbol, LobbyType lobbyType, TeamIndex teamIndex, ERGameServerStartSession.SessionSettings sessionSettings, Int64? RegionSymbol = null)
         {
-            return new MatchingSession(userId, null, channel, gameTypeSymbol, levelSymbol, lobbyType, teamIndex, sessionSettings);
+            return new MatchingSession(userId, null, channel, gameTypeSymbol, levelSymbol, lobbyType, teamIndex, sessionSettings, RegionSymbol);
         }
         public static MatchingSession FromFindSessionCriteria(XPlatformId userId, Guid? channel, long? gameTypeSymbol, TeamIndex teamIndex, ERGameServerStartSession.SessionSettings sessionSettings)
         {

--- a/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
+++ b/EchoRelay.Core/Server/Services/ServerDB/GameServerRegistry.cs
@@ -77,7 +77,7 @@ namespace EchoRelay.Core.Server.Services.ServerDB
 
         public IEnumerable<RegisteredGameServer> FilterGameServers(int? findMax = null, ulong? serverId = null, Guid? sessionId = null,
             HashSet<(uint InternalAddr, uint ExternalAddr)>? addresses = null, ushort? port = null,
-            long? gameTypeSymbol = null, long? levelSymbol = null, Guid? channel = null, bool? locked = null, LobbyType[]? lobbyTypes = null, TeamIndex? requestedTeam = null, bool unfilledServerOnly = true)
+            long? gameTypeSymbol = null, long? levelSymbol = null, Guid? channel = null, bool? locked = null, LobbyType[]? lobbyTypes = null, TeamIndex? requestedTeam = null, bool unfilledServerOnly = true, long? regionSymbol = null)
         {
             // Filter through all game servers
             List<RegisteredGameServer> filteredGameServers = new List<RegisteredGameServer>();
@@ -93,6 +93,10 @@ namespace EchoRelay.Core.Server.Services.ServerDB
                 else if (addresses != null && !addresses.Contains((gameServer.InternalAddress.ToUInt32(), gameServer.ExternalAddress.ToUInt32())))
                     continue;
                 else if (port != null && gameServer.Peer.Port != port)
+                    continue;
+                
+                // If Region is supplied filter by RegionSybmol.
+                if(regionSymbol != null && gameServer.RegionSymbol != regionSymbol)
                     continue;
 
                 // If the session is started, filter on that criteria.

--- a/EchoRelay.GameServer/messages.h
+++ b/EchoRelay.GameServer/messages.h
@@ -47,7 +47,7 @@ struct ERLobbyRegistrationRequest
 	UINT64 serverId;
 	UINT32 internalIp;
 	UINT16 port;
-	BYTE padding[4];
+	BYTE padding[10]; // Was 4, but somehow compiled into 10, so we'll just go with it and set just in case it compiles differently in the future.
 	EchoVR::SymbolId regionId;
 	EchoVR::SymbolId versionLock;
 };


### PR DESCRIPTION
Filters gameservers when -region tag is supplied from client, and compares to -serverregion tag supplied from Dedicated servers.

- If no servers in region are available, use ping based matchmaking.