### PR TITLE
Add Sessions API, and Push API Updates to Client

### DIFF
--- a/EchoRelay.API/Controllers/SessionsController.cs
+++ b/EchoRelay.API/Controllers/SessionsController.cs
@@ -1,0 +1,67 @@
+﻿using EchoRelay.Core.Game;
+using EchoRelay.Core.Server.Services.ServerDB;
+using EchoRelay.Core.Server.Storage;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+
+namespace EchoRelay.API.Controllers
+{
+    [Route("sessions/")]
+    [ApiController]
+    public class SessionsController : ControllerBase
+    {
+        static GameServerRegistry? Registry => ApiServer.Instance?.RelayServer.ServerDBService.Registry;
+
+        [HttpGet]
+        public IActionResult Get(int pageNumber = 1, int pageSize = 10)
+        {
+            try
+            {
+                if (pageNumber < 1)
+                {
+                    return BadRequest("Invalid page number");
+                }
+
+                if (Registry == null)
+                {
+                    return StatusCode((int)HttpStatusCode.InternalServerError, "Registry is null");
+                }
+
+                var servers = Registry.RegisteredGameServersBySessionId.Keys;
+                var skip = (pageNumber - 1) * pageSize;
+                var page = servers.Skip(skip).Take(pageSize);
+                return Ok(page.Select(x => x.ToString()).ToArray());
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpGet("{sessionId}")]
+        public IActionResult AccountGet(Guid sessionId)
+        {
+            try
+            {
+                if (Registry == null)
+                {
+                    return StatusCode((int)HttpStatusCode.InternalServerError, "Registry is null");
+                }
+
+                var server = Registry.GetGameServer(sessionId);
+                if (server == null)
+                {
+                    return NotFound("Session not found");
+                }
+
+                var serverInfo = new SessionInfo(server);
+                return Ok(serverInfo);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+    }
+}

--- a/EchoRelay.API/SessionInfo.cs
+++ b/EchoRelay.API/SessionInfo.cs
@@ -33,7 +33,10 @@ namespace EchoRelay.API
         public bool Locked { get; set; }
 
         [JsonProperty("playerSessions")]
-        public Dictionary<string, (string peer, short team)> PlayerSessions { get; set; }
+        public Dictionary<string, string> PlayerSessions { get; set; }
+
+        [JsonProperty("teamSessions")]
+        public Dictionary<string, short> TeamSessions { get; set; }
 
         public SessionInfo(RegisteredGameServer gameServer)
         {
@@ -51,11 +54,13 @@ namespace EchoRelay.API
             PlayerLimit = gameServer.SessionPlayerLimits.TotalPlayerLimit;
             ActivePlayerLimit = gameServer.SessionPlayerLimits.FixedActiveGameParticipantTarget;
             Locked = gameServer.SessionLocked;
-            PlayerSessions = new Dictionary<string, (string peer, short team)>();
+            PlayerSessions = new Dictionary<string, string>();
+            TeamSessions = new Dictionary<string,  short>();
 
             foreach (var player in gameServer.SessionPlayerSessions)
             {
-                PlayerSessions.Add(player.Key.ToString(), (player.Value.peer.UserId.ToString(), (short)player.Value.requestedTeam));
+                PlayerSessions.Add(player.Key.ToString(), player.Value.peer.UserId.ToString());
+                TeamSessions.Add(player.Key.ToString(), (short)player.Value.requestedTeam);
             }
         }
     }

--- a/EchoRelay.API/SessionInfo.cs
+++ b/EchoRelay.API/SessionInfo.cs
@@ -39,7 +39,7 @@ namespace EchoRelay.API
         {
             if (!gameServer.SessionStarted)
             {
-                throw new Exception("Session has not started.");
+                throw new Exception("No session found.");
             }
 
             ServerId = gameServer.ServerId;

--- a/EchoRelay.API/SessionInfo.cs
+++ b/EchoRelay.API/SessionInfo.cs
@@ -1,0 +1,62 @@
+﻿using EchoRelay.Core.Server.Services.ServerDB;
+using Newtonsoft.Json;
+
+namespace EchoRelay.API
+{
+    public class SessionInfo
+    {
+        [JsonProperty("serverId")]
+        public ulong ServerId { get; set; }
+
+        [JsonProperty("sessionId")]
+        public string SessionId { get; set; }
+
+        [JsonProperty("lobbyType")]
+        public int LobbyType { get; set; }
+
+        [JsonProperty("gameType")]
+        public long GameType { get; set; }
+
+        [JsonProperty("level")]
+        public long? Level { get; set; }
+
+        [JsonProperty("channel")]
+        public string Channel { get; set; }
+
+        [JsonProperty("activePlayerLimit")]
+        public int? ActivePlayerLimit { get; set; }
+
+        [JsonProperty("playerLimit")]
+        public int PlayerLimit { get; set; }
+
+        [JsonProperty("locked")]
+        public bool Locked { get; set; }
+
+        [JsonProperty("playerSessions")]
+        public Dictionary<string, (string peer, short team)> PlayerSessions { get; set; }
+
+        public SessionInfo(RegisteredGameServer gameServer)
+        {
+            if (!gameServer.SessionStarted)
+            {
+                throw new Exception("Session has not started.");
+            }
+
+            ServerId = gameServer.ServerId;
+            SessionId = gameServer.SessionId.ToString();
+            LobbyType = (short)gameServer.SessionLobbyType;
+            GameType = (long)gameServer.SessionGameTypeSymbol;
+            Level = gameServer.SessionLevelSymbol;
+            Channel = gameServer.SessionChannel.ToString();
+            PlayerLimit = gameServer.SessionPlayerLimits.TotalPlayerLimit;
+            ActivePlayerLimit = gameServer.SessionPlayerLimits.FixedActiveGameParticipantTarget;
+            Locked = gameServer.SessionLocked;
+            PlayerSessions = new Dictionary<string, (string peer, short team)>();
+
+            foreach (var player in gameServer.SessionPlayerSessions)
+            {
+                PlayerSessions.Add(player.Key.ToString(), (player.Value.peer.UserId.ToString(), (short)player.Value.requestedTeam));
+            }
+        }
+    }
+}

--- a/EchoRelay.Core/Server/Messages/Login/UpdateProfileFailure.cs
+++ b/EchoRelay.Core/Server/Messages/Login/UpdateProfileFailure.cs
@@ -1,0 +1,81 @@
+﻿using EchoRelay.Core.Game;
+using EchoRelay.Core.Utils;
+using System.Net;
+
+namespace EchoRelay.Core.Server.Messages.Login
+{
+    /// <summary>
+    /// A message from server to client indicating their <see cref="UpdateProfile"/> request failed.
+    /// </summary>
+    public class UpdateProfileFailure : Message
+    {
+        #region Fields
+        /// <summary>
+        /// The unique 64-bit symbol denoting the type of message.
+        /// </summary>
+        public override long MessageTypeSymbol => -990363271445940671;
+
+        /// <summary>
+        /// The identifier of the associated user.
+        /// </summary>
+        public XPlatformId UserId;
+        public ulong _statusCode;
+        /// <summary>
+        /// The status code returned with the failure.
+        /// </summary>
+        public HttpStatusCode StatusCode
+        {
+            get { return (HttpStatusCode)_statusCode; }
+            set { _statusCode = (ulong)value; }
+        }
+        /// <summary>
+        /// The message returned with the failure.
+        /// </summary>
+        public string Message;
+        #endregion
+
+        #region Constructor
+        /// <summary>
+        /// Initializes a new <see cref="LoggedInUserProfileFailure"/> message.
+        /// </summary>
+        public UpdateProfileFailure()
+        {
+            UserId = new XPlatformId();
+            StatusCode = HttpStatusCode.InternalServerError;
+            Message = "";
+        }
+        /// <summary>
+        /// Initializes a new <see cref="LoggedInUserProfileFailure"/> message with the provided arguments.
+        /// </summary>
+        /// <param name="userId">The identifier of the associated user.</param>
+        /// <param name="statusCode">The status code returned with the failure.</param>
+        /// <param name="message">The message returned with the failure.</param>
+        public UpdateProfileFailure(XPlatformId userId, HttpStatusCode statusCode, string message)
+        {
+            UserId = userId;
+            StatusCode = statusCode;
+            Message = message;
+        }
+
+
+        #endregion
+
+        #region Functions
+        /// <summary>
+        /// Streams the message data in/out based on the streaming mode set.
+        /// </summary>
+        /// <param name="io">The stream to read/write data from/to.</param>
+        public override void Stream(StreamIO io)
+        {
+            UserId.Stream(io);
+            io.Stream(ref _statusCode);
+            io.Stream(ref Message, true);
+        }
+
+        public override string ToString()
+        {
+            return $"{GetType().Name}(user_id={UserId}, status={StatusCode}, msg=\"{Message}\")";
+        }
+        #endregion
+    }
+}

--- a/EchoRelay.Core/Server/Services/Login/LoginService.cs
+++ b/EchoRelay.Core/Server/Services/Login/LoginService.cs
@@ -453,7 +453,8 @@ namespace EchoRelay.Core.Server.Services.Login
             // Verify the session details provided
             if (!CheckUserSessionValid(request.Session, request.UserId))
             {
-                // TODO: Send UpdateProfileFailure(?)
+                await sender.Send(new UpdateProfileFailure(request.UserId, HttpStatusCode.BadRequest, "Authentication failed"));
+                await sender.Send(new TcpConnectionUnrequireEvent());
                 return;
             }
 
@@ -461,14 +462,16 @@ namespace EchoRelay.Core.Server.Services.Login
             AccountResource? account = Storage.Accounts.Get(request.UserId);
             if (account == null)
             {
-                // TODO: Send UpdateProfileFailure(?)
+                await sender.Send(new UpdateProfileFailure(request.UserId, HttpStatusCode.BadRequest, "Failed to obtain profile"));
+                await sender.Send(new TcpConnectionUnrequireEvent());
                 return;
             }
 
             // Verify the account identifier did not change (avoids overwriting another profile in storage, as it is the storage key).
             if (request.ClientProfile.XPlatformId != request.UserId.ToString())
             {
-                // TODO: Send UpdateProfileFailure(?)
+                await sender.Send(new UpdateProfileFailure(request.UserId, HttpStatusCode.BadRequest, "Invalid account identifier"));
+                await sender.Send(new TcpConnectionUnrequireEvent());
                 return;
             }
 


### PR DESCRIPTION
This allows you to get info about a session such as game/level type and players in the session, same interface as servers/accounts
Also, when the api changes a profile, it will notify the client if it is logged in
I also added the UpdateProfileFailure message from testing, thought it would be nice to include