### PR TITLE
Exclude current session from matchmaking

### DIFF
--- a/EchoRelay.Core/Server/Messages/Matching/LobbyFindSessionRequestv11.cs
+++ b/EchoRelay.Core/Server/Messages/Matching/LobbyFindSessionRequestv11.cs
@@ -40,8 +40,11 @@ namespace EchoRelay.Core.Server.Messages.Matching
 
         // TODO
         public ulong Unk1;
-        public UInt128 Unk2;
 
+        /// <summary>
+        /// Guid of the server the client is currently connected to.
+        /// </summary>
+        public Guid CurrentSession;
         /// <summary>
         /// The channel requested for the session.
         /// </summary>
@@ -73,7 +76,7 @@ namespace EchoRelay.Core.Server.Messages.Matching
             PlatformSymbol = -1;
             Session = new Guid();
             Unk1 = 0;
-            Unk2 = 0;
+            CurrentSession = new Guid();
             ChannelUUID = new Guid();
             SessionSettings = new ERGameServerStartSession.SessionSettings();
             UserId = new XPlatformId();
@@ -94,7 +97,7 @@ namespace EchoRelay.Core.Server.Messages.Matching
             io.Stream(ref PlatformSymbol);
             io.Stream(ref Session);
             io.Stream(ref Unk1);
-            io.Stream(ref Unk2);
+            io.Stream(ref CurrentSession);
             io.Stream(ref ChannelUUID);
             io.StreamJSON(ref SessionSettings, true, JSONCompressionMode.None);
             UserId.Stream(io);
@@ -121,7 +124,7 @@ namespace EchoRelay.Core.Server.Messages.Matching
                 $"platform={PlatformSymbol}, " +
                 $"session={Session}, " +
                 $"unk1={Unk1}, " +
-                $"unk2={Unk2}, " +
+                $"currentsession={CurrentSession}, " +
                 $"channel={ChannelUUID}, " +
                 $"session_settings={JObject.FromObject(SessionSettings).ToString(Newtonsoft.Json.Formatting.None)}, " +
                 $"user_id={UserId}, " +

--- a/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
+++ b/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
@@ -60,7 +60,7 @@ namespace EchoRelay.Core.Server.Services.Matching
         private async Task ProcessCreateSessionRequestv9(Peer sender, LobbyCreateSessionRequestv9 request)
         {
             // Set the matching data for our user to provide context to matching operations moving forward.
-            sender.SetSessionData(MatchingSession.FromCreateSessionCriteria(request.UserId, request.ChannelUUID, request.GameTypeSymbol, request.LevelSymbol, request.LobbyType, (TeamIndex)request.TeamIndex, request.SessionSettings,request.RegionSymbol));
+            sender.SetSessionData(MatchingSession.FromCreateSessionCriteria(request.UserId, request.ChannelUUID, request.GameTypeSymbol, request.LevelSymbol, request.LobbyType, (TeamIndex)request.TeamIndex, request.SessionSettings, request.RegionSymbol)) ;
 
             // Process the underlying request.
             await ProcessMatchingSession(sender, request.Session, request.UserId);
@@ -74,7 +74,7 @@ namespace EchoRelay.Core.Server.Services.Matching
         private async Task ProcessFindSessionRequestv11(Peer sender, LobbyFindSessionRequestv11 request)
         {
             // Set the matching data for our user to provide context to matching operations moving forward.
-            sender.SetSessionData(MatchingSession.FromFindSessionCriteria(request.UserId, request.ChannelUUID, request.GameTypeSymbol, (TeamIndex)request.TeamIndex, request.SessionSettings));
+            sender.SetSessionData(MatchingSession.FromFindSessionCriteria(request.UserId, request.ChannelUUID, request.GameTypeSymbol, (TeamIndex)request.TeamIndex, request.CurrentSession, request.SessionSettings));
 
             // Process the underlying request.
             await ProcessMatchingSession(sender, request.Session, request.UserId);
@@ -204,6 +204,9 @@ namespace EchoRelay.Core.Server.Services.Matching
                 unfilledServerOnly: true
             );
             }
+
+            // Case when pressing "New Lobby" button in the menu.
+            gameServers = gameServers.Where(x => x.SessionId == null || x.SessionId != matchingSession.CurrentSession);
 
             // If we only have one game server, immediately connect the peer. Otherwise, perform a ping request to determine the lowest ping server.
             if (gameServers.Count() == 1)

--- a/EchoRelay.Core/Server/Services/Matching/MatchingSession.cs
+++ b/EchoRelay.Core/Server/Services/Matching/MatchingSession.cs
@@ -33,12 +33,13 @@ namespace EchoRelay.Core.Server.Services.Matching
         }
         public ERGameServerStartSession.SessionSettings SessionSettings { get; private set; }
         public TeamIndex TeamIndex { get; private set; }
+        public Guid? CurrentSession;
 
         public long? RegionSymbol { get; private set; }
 
         public RegisteredGameServer? MatchedGameServer { get; set; }
         public Guid? MatchedSessionId { get; set; }
-        private MatchingSession(XPlatformId userId, Guid? lobbyId, Guid? channel, long? gameTypeSymbol, long? levelSymbol, LobbyType newSessionLobbyType, TeamIndex teamIndex, ERGameServerStartSession.SessionSettings sessionSettings, Int64? regionSymbol = null)
+        private MatchingSession(XPlatformId userId, Guid? lobbyId, Guid? channel, long? gameTypeSymbol, long? levelSymbol, LobbyType newSessionLobbyType, TeamIndex teamIndex, Guid? currentSession, ERGameServerStartSession.SessionSettings sessionSettings, Int64? regionSymbol = null)
         {
             UserId = userId;
             LobbyId = lobbyId;
@@ -47,22 +48,23 @@ namespace EchoRelay.Core.Server.Services.Matching
             LevelSymbol = levelSymbol;
             NewSessionLobbyType = newSessionLobbyType;
             TeamIndex = teamIndex;
+            CurrentSession = currentSession;
             SessionSettings = sessionSettings;
             RegionSymbol = regionSymbol;
         }
 
         public static MatchingSession FromCreateSessionCriteria(XPlatformId userId, Guid? channel, long? gameTypeSymbol, long? levelSymbol, LobbyType lobbyType, TeamIndex teamIndex, ERGameServerStartSession.SessionSettings sessionSettings, Int64? RegionSymbol = null)
         {
-            return new MatchingSession(userId, null, channel, gameTypeSymbol, levelSymbol, lobbyType, teamIndex, sessionSettings, RegionSymbol);
+            return new MatchingSession(userId, null, channel, gameTypeSymbol, levelSymbol, lobbyType, teamIndex, null, sessionSettings, RegionSymbol);
         }
-        public static MatchingSession FromFindSessionCriteria(XPlatformId userId, Guid? channel, long? gameTypeSymbol, TeamIndex teamIndex, ERGameServerStartSession.SessionSettings sessionSettings)
+        public static MatchingSession FromFindSessionCriteria(XPlatformId userId, Guid? channel, long? gameTypeSymbol, TeamIndex teamIndex, Guid? currentSession, ERGameServerStartSession.SessionSettings sessionSettings)
         {
-            return new MatchingSession(userId, null, channel, gameTypeSymbol, null, LobbyType.Public, teamIndex, sessionSettings);
+            return new MatchingSession(userId, null, channel, gameTypeSymbol, null, LobbyType.Public, teamIndex, currentSession, sessionSettings);
         }
 
         public static MatchingSession FromJoinSpecificSessionCriteria(XPlatformId userId, Guid? lobbyId, TeamIndex teamIndex, ERGameServerStartSession.SessionSettings sessionSettings)
         {
-            return new MatchingSession(userId, lobbyId, null, null, null, LobbyType.Public, teamIndex, sessionSettings);
+            return new MatchingSession(userId, lobbyId, null, null, null, LobbyType.Public, teamIndex, null, sessionSettings);
         }
     }
 }


### PR DESCRIPTION
This is the case when pressing the "New Lobby" button in the menu.

- Unk2 field labeled as as the current session