### PR TITLE
Prevent body-specific tint applying broadly

### DIFF
--- a/EchoRelay.Core/Server/Services/Login/LoginService.cs
+++ b/EchoRelay.Core/Server/Services/Login/LoginService.cs
@@ -182,6 +182,8 @@ namespace EchoRelay.Core.Server.Services.Login
                             account.Profile.Server.Loadout.Instances.Unified.Slots.DecalBody = itemName;
                             break;
                         case "tint":
+                            // Equipping tint_chassis_default to heraldry tint causes every heraldry equip to be pitch black.
+                            // Guessing wherever this pulls the tint from doesn't exist on heraldry equippables.
                             if (itemName != "tint_chassis_default")
                             {
                                 account.Profile.Server.Loadout.Instances.Unified.Slots.Tint = itemName;

--- a/EchoRelay.Core/Server/Services/Login/LoginService.cs
+++ b/EchoRelay.Core/Server/Services/Login/LoginService.cs
@@ -182,7 +182,10 @@ namespace EchoRelay.Core.Server.Services.Login
                             account.Profile.Server.Loadout.Instances.Unified.Slots.DecalBody = itemName;
                             break;
                         case "tint":
-                            account.Profile.Server.Loadout.Instances.Unified.Slots.Tint = itemName;
+                            if (itemName != "tint_chassis_default")
+                            {
+                                account.Profile.Server.Loadout.Instances.Unified.Slots.Tint = itemName;
+                            }
                             account.Profile.Server.Loadout.Instances.Unified.Slots.TintBody = itemName;
                             /*account.Profile.Server.Loadout.Instances.Unified.Slots.TintAlignmentA = itemName;
                             account.Profile.Server.Loadout.Instances.Unified.Slots.TintAlignmentB = itemName;*/


### PR DESCRIPTION
When selecting 'No Tint' as your Chassis tint, All other cosmetics that can have a Tint equipped show up as black.

- Bandaid fix to prevent setting "tint_chassis_default" to anything but TintBody.