### PR TITLE
Discard current server from candidates in ProcessPingResponse

### DIFF
--- a/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
+++ b/EchoRelay.Core/Server/Services/Matching/MatchingService.cs
@@ -298,6 +298,8 @@ namespace EchoRelay.Core.Server.Services.Matching
                     unfilledServerOnly: true
                 );
 
+                // Case when pressing "New Lobby" button in the menu.
+                gameServers = gameServers.Where(x => x.SessionId == null || x.SessionId != matchingSession.CurrentSession);
 
                 // Determine if the user is trying to join a private match.
                 bool isPrivateMatch = false;


### PR DESCRIPTION
Bug arose where previously discarded server would remain if there were multiple servers being hosted on the same IP.

- Filter candidate game servers against CurrentSession in ProcessPingResponse alongside ProcessMatchingSession.
